### PR TITLE
fix: handle self-closing HTML inside parseable HTML

### DIFF
--- a/index.spec.js
+++ b/index.spec.js
@@ -554,6 +554,15 @@ describe('markdown-to-jsx', () => {
                 expect($element.children[0].children[0].tagName).toBe('STRONG');
                 expect($element.children[0].children[0].textContent).toBe('code');
             });
+
+            it('handles self-closing html inside parsable html (regression)', () => {
+                const element = render(compiler('<a href="https://opencollective.com/react-dropzone/sponsor/0/website" target="_blank"><img src="https://opencollective.com/react-dropzone/sponsor/0/avatar.svg"></a>'));
+                const $element = dom(element);
+
+                expect($element.tagName).toBe('P');
+                expect($element.children[0].tagName).toBe('A');
+                expect($element.children[0].children[0].tagName).toBe('IMG');
+            });
         });
 
         describe('horizontal rules', () => {


### PR DESCRIPTION
Also made a change to omit interim wrappers where possible in
situations where dangerouslySetInnerHTML is unavoidable.

fixes #101 