### PR TITLE
Replace prepublishOnly script with in-publish package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "budo": "^9.2.0",
     "bundle-collapser": "^1.2.1",
     "codecov": "^2.1.0",
+    "in-publish": "^2.0.0",
     "jest-cli": "^19.0.2",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
@@ -55,7 +56,7 @@
     ]
   },
   "scripts": {
-    "prepublishOnly": "npm run es5",
+    "prepublish": "in-publish && npm run es5 || not-in-publish",
     "es5": "babel index.js --out-file index.es5.js",
     "site:css": "stylus -u autoprefixer-stylus site.styl -o docs/css/style.css",
     "site:css:release": "npm run site:css -- -c",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2251,6 +2251,10 @@ ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
+in-publish@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.0.tgz#e20ff5e3a2afc2690320b6dc552682a9c7fadf51"
+
 indent-string@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
@@ -3755,7 +3759,7 @@ replace-ext@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
-request@2.79.0:
+request@2.79.0, request@^2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -3780,7 +3784,7 @@ request@2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
-request@^2.79.0, request@^2.81.0:
+request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:


### PR DESCRIPTION
Fixes #104.

Picture proof that prepublish script is run on install but does not execute `npm run es5`:

![image](https://cloud.githubusercontent.com/assets/3505504/25473897/84b20ee8-2b31-11e7-9d21-2eb6720285ba.png)
