### PR TITLE
Allow custom react function overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@
 
 <!-- TOC -->
 
-- [Markdown Component for React, Preact + Friends](#markdown-component-for-react-preact--friends)
+- [Markdown Component for React, Preact + Friends](#markdown-component-for-react-preact-friends)
     - [Installation](#installation)
     - [Usage](#usage)
         - [Parsing Options](#parsing-options)
-        - [Override Any HTML Tag's Representation](#override-any-html-tags-representation)
-        - [Rendering Arbitrary React Components](#rendering-arbitrary-react-components)
+            - [options.forceBlock](#optionsforceblock)
+            - [options.forceInline](#optionsforceinline)
+            - [options.overrides - Override Any HTML Tag's Representation](#optionsoverrides---override-any-html-tags-representation)
+            - [options.overrides - Rendering Arbitrary React Components](#optionsoverrides---rendering-arbitrary-react-components)
+            - [options.rules - Rendering custom React components for Markdown rules](#optionsrules---rendering-custom-react-components-for-markdown-rules)
+- [TODO: Fix](#todo-fix)
         - [Getting the smallest possible bundle size](#getting-the-smallest-possible-bundle-size)
         - [Usage with Preact](#usage-with-preact)
     - [Using The Compiler Directly](#using-the-compiler-directly)
@@ -21,15 +25,15 @@
 
 `markdown-to-jsx` uses a fork of [simple-markdown](https://github.com/Khan/simple-markdown) as its parsing engine and extends it in a number of ways to make your life easier. Notably, this package offers the following additional benefits:
 
-  - Arbitrary HTML is supported and parsed into the appropriate JSX representation
-    without `dangerouslySetInnerHTML`
+* Arbitrary HTML is supported and parsed into the appropriate JSX representation
+  without `dangerouslySetInnerHTML`
 
-  - Any HTML tags rendered by the compiler and/or `<Markdown>` component can be overridden to include additional
-    props or even a different HTML representation entirely.
+* Any HTML tags rendered by the compiler and/or `<Markdown>` component can be overridden to include additional
+  props or even a different HTML representation entirely.
 
-  - GFM task list support.
+* GFM task list support.
 
-  - Fenced code blocks with [highlight.js](https://highlightjs.org/) support.
+* Fenced code blocks with [highlight.js](https://highlightjs.org/) support.
 
 All this clocks in at around 5 kB gzipped, which is a fraction of the size of most other React markdown components.
 
@@ -54,15 +58,11 @@ ES6-style usage\*:
 ```jsx
 import Markdown from 'markdown-to-jsx';
 import React from 'react';
-import {render} from 'react-dom';
+import { render } from 'react-dom';
 
 const markdown = `# Hello world!`.trim();
 
-render((
-    <Markdown>
-        # Hello world!
-    </Markdown>
-), document.body);
+render(<Markdown># Hello world!</Markdown>, document.body);
 
 /*
     renders:
@@ -71,11 +71,12 @@ render((
  */
 ```
 
-\* __NOTE: JSX does not natively preserve newlines in multiline text. In general, writing markdown directly in JSX is discouraged and it's a better idea to keep your content in separate .md files and require them, perhaps using webpack's [raw-loader](https://github.com/webpack-contrib/raw-loader).__
+\* **NOTE: JSX does not natively preserve newlines in multiline text. In general, writing markdown directly in JSX is discouraged and it's a better idea to keep your content in separate .md files and require them, perhaps using webpack's [raw-loader](https://github.com/webpack-contrib/raw-loader).**
 
 ### Parsing Options
 
 #### options.forceBlock
+
 By default, the compiler will try to make an intelligent guess about the content passed and wrap it in a `<div>`, `<p>`, or `<span>` as needed to satisfy the "inline"-ness of the markdown. For instance, this string would be considered "inline":
 
 ```md
@@ -91,9 +92,7 @@ But this string would be considered "block" due to the existence of a header tag
 However, if you really want all input strings to be treated as "block" layout, simply pass `options.forceBlock = true` like this:
 
 ```jsx
-<Markdown options={{ forceBlock: true }}>
-    Hello there old chap!
-</Markdown>
+<Markdown options={{ forceBlock: true }}>Hello there old chap!</Markdown>;
 
 // or
 
@@ -101,16 +100,15 @@ compiler('Hello there old chap!', { forceBlock: true });
 
 // renders
 
-<p>Hello there old chap!</p>
+<p>Hello there old chap!</p>;
 ```
 
 #### options.forceInline
+
 The inverse is also available by passing `options.forceInline = true`:
 
 ```jsx
-<Markdown options={{ forceInline: true }}>
-    # You got it babe!
-</Markdown>
+<Markdown options={{ forceInline: true }}># You got it babe!</Markdown>;
 
 // or
 
@@ -118,7 +116,7 @@ compiler('# You got it babe!', { forceInline: true });
 
 // renders
 
-<span># You got it babe!</span>
+<span># You got it babe!</span>;
 ```
 
 #### options.overrides - Override Any HTML Tag's Representation
@@ -128,26 +126,29 @@ Pass the `options.overrides` prop to the compiler or `<Markdown>` component to s
 ```jsx
 import Markdown from 'markdown-to-jsx';
 import React from 'react';
-import {render} from 'react-dom';
+import { render } from 'react-dom';
 
 // surprise, it's a div instead!
-const MyParagraph = ({children, ...props}) => (<div {...props}>{children}</div>);
+const MyParagraph = ({ children, ...props }) => (
+  <div {...props}>{children}</div>
+);
 
-render((
-    <Markdown
-        options={{
-            overrides: {
-                h1: {
-                    component: MyParagraph,
-                    props: {
-                        className: 'foo',
-                    },
-                },
-            },
-        }}>
-        # Hello world!
-    </Markdown>
-), document.body);
+render(
+  <Markdown
+    options={{
+      overrides: {
+        h1: {
+          component: MyParagraph,
+          props: {
+            className: 'foo'
+          }
+        }
+      }
+    }}>
+    # Hello world!
+  </Markdown>,
+  document.body
+);
 
 /*
     renders:
@@ -170,12 +171,12 @@ If you only wish to provide a component override, a simplified syntax is availab
 
 Depending on the type of element, there are some props that must be preserved to ensure the markdown is converted as intended. They are:
 
-- `a`: `title`, `href`
-- `img`: `title`, `alt`, `src`
-- `input[type="checkbox"]`: `checked`, `readonly` (specifically, the one rendered by a GFM task list)
-- `ol`: `start`
-- `td`: `style`
-- `th`: `style`
+* `a`: `title`, `href`
+* `img`: `title`, `alt`, `src`
+* `input[type="checkbox"]`: `checked`, `readonly` (specifically, the one rendered by a GFM task list)
+* `ol`: `start`
+* `td`: `style`
+* `th`: `style`
 
 Any conflicts between passed `props` and the specific properties above will be resolved in favor of `markdown-to-jsx`'s code.
 
@@ -188,7 +189,7 @@ By adding an override for the components you plan to use in markdown documents, 
 ```jsx
 import Markdown from 'markdown-to-jsx';
 import React from 'react';
-import {render} from 'react-dom';
+import { render } from 'react-dom';
 
 import DatePicker from './date-picker';
 
@@ -201,17 +202,19 @@ as well as a default timezone.
 <DatePicker biasTowardDateTime="2017-12-05T07:39:36.091Z" timezone="UTC+5" />
 `;
 
-render((
-    <Markdown
-        children={md}
-        options={{
-            overrides: {
-                DatePicker: {
-                    component: DatePicker,
-                },
-            },
-        }} />
-), document.body);
+render(
+  <Markdown
+    children={md}
+    options={{
+      overrides: {
+        DatePicker: {
+          component: DatePicker
+        }
+      }
+    }}
+  />,
+  document.body
+);
 ```
 
 `markdown-to-jsx` also handles JSX interpolation syntax, but in a minimal way to not introduce a potential attack vector. Interpolations are sent to the component as their raw string, which the consumer can then `eval()` or process as desired to their security needs.
@@ -221,7 +224,7 @@ In the following case, `DatePicker` could simply run `parseInt()` on the passed 
 ```jsx
 import Markdown from 'markdown-to-jsx';
 import React from 'react';
-import {render} from 'react-dom';
+import { render } from 'react-dom';
 
 import DatePicker from './date-picker';
 
@@ -238,17 +241,19 @@ as well as a default timezone.
 />
 `;
 
-render((
-    <Markdown
-        children={md}
-        options={{
-            overrides: {
-                DatePicker: {
-                    component: DatePicker,
-                },
-            },
-        }} />
-), document.body);
+render(
+  <Markdown
+    children={md}
+    options={{
+      overrides: {
+        DatePicker: {
+          component: DatePicker
+        }
+      }
+    }}
+  />,
+  document.body
+);
 ```
 
 Another possibility is to use something like [recompose's `withProps()` HOC](https://github.com/acdlite/recompose/blob/master/docs/API.md#withprops) to create various pregenerated scenarios and then reference them by name in the markdown:
@@ -256,17 +261,17 @@ Another possibility is to use something like [recompose's `withProps()` HOC](htt
 ```jsx
 import Markdown from 'markdown-to-jsx';
 import React from 'react';
-import {render} from 'react-dom';
+import { render } from 'react-dom';
 import withProps from 'recompose/withProps';
 
 import DatePicker from './date-picker';
 
 const DecemberDatePicker = withProps({
-    range: {
-        start: new Date('2017-12-01'),
-        end: new Date('2017-12-31'),
-    },
-    timezone: 'UTC+5',
+  range: {
+    start: new Date('2017-12-01'),
+    end: new Date('2017-12-31')
+  },
+  timezone: 'UTC+5'
 })(DatePicker);
 
 const md = `
@@ -286,17 +291,58 @@ Here's an example of a DatePicker pre-set to only the month of December:
 <DecemberDatePicker />
 `;
 
-render((
-    <Markdown
-        children={md}
-        options={{
-            overrides: {
-                DatePicker,
-                DecemberDatePicker,
-            },
-        }} />
-), document.body);
+render(
+  <Markdown
+    children={md}
+    options={{
+      overrides: {
+        DatePicker,
+        DecemberDatePicker
+      }
+    }}
+  />,
+  document.body
+);
 ```
+
+#### options.rules - Rendering custom React components for Markdown rules
+
+# TODO: Fix
+
+While `options.overrides` allows you to override the individual components output, `options.rules` gives you complete flexibility to return whatever React component you want for each kind of Markdown type (`text`, `codeBlock`...). All the rules are defined on the [`RULES`](index.js#621) constant and are exported as `rules`. If you wanted to see what rules are available, you can do:
+
+```jsx
+import { rules } from 'markdown-to-jsx';
+
+function printRules() {
+  console.log(Object.keys(rules));
+}
+```
+
+markdown-to-jsx expects the following props on each rule:
+
+```javascript
+{
+    // A RegEx to match the Markdown
+    match: blockRegex(/^(?: {4}[^\n]+\n*)+(?:\n *)+\n/),
+    // The parse priority
+    order: PARSE_PRIORITY_MAX, // = 1
+    // How to parse the element, output will be passed to the `react` method
+    parse(capture, parse, state) {
+      return {
+        content: 'blah'
+      };
+    },
+    // Returns the React component representation of this Markdown rule
+    react(node, output, state) {
+      return (
+        <p key={state.key}>This is my awesome component: {node.content}</p>
+      );
+    }
+  },
+```
+
+You may use this function to return custom component objects on the server-side which need to be hydrated by the client (with `react-dom/server`).
 
 ### Getting the smallest possible bundle size
 
@@ -304,10 +350,10 @@ Many development conveniences are placed behind `process.env.NODE_ENV !== "produ
 
 Here are instructions for some of the popular bundlers:
 
-- [webpack](https://webpack.js.org/guides/production/#specify-the-environment)
-- [browserify plugin](https://github.com/hughsk/envify)
-- [parcel](https://parceljs.org/production.html)
-- [fuse-box](http://fuse-box.org/plugins/replace-plugin#notes)
+* [webpack](https://webpack.js.org/guides/production/#specify-the-environment)
+* [browserify plugin](https://github.com/hughsk/envify)
+* [parcel](https://parceljs.org/production.html)
+* [fuse-box](http://fuse-box.org/plugins/replace-plugin#notes)
 
 ### Usage with Preact
 
@@ -318,9 +364,9 @@ Everything will work just fine! Simply [Alias `react` to `preact-compat`](https:
 If desired, the compiler function is a "named" export on the `markdown-to-jsx` module:
 
 ```jsx
-import {compiler} from 'markdown-to-jsx';
+import { compiler } from 'markdown-to-jsx';
 import React from 'react';
-import {render} from 'react-dom';
+import { render } from 'react-dom';
 
 render(compiler('# Hello world!'), document.body);
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
             - [options.overrides - Override Any HTML Tag's Representation](#optionsoverrides---override-any-html-tags-representation)
             - [options.overrides - Rendering Arbitrary React Components](#optionsoverrides---rendering-arbitrary-react-components)
             - [options.react - Rendering custom React components for Markdown rules](#optionsreact---rendering-custom-react-components-for-markdown-rules)
-- [TODO: Fix](#todo-fix)
         - [Getting the smallest possible bundle size](#getting-the-smallest-possible-bundle-size)
         - [Usage with Preact](#usage-with-preact)
     - [Using The Compiler Directly](#using-the-compiler-directly)
@@ -306,8 +305,6 @@ render(
 ```
 
 #### options.react - Rendering custom React components for Markdown rules
-
-# TODO: Fix
 
 While `options.overrrides` allows you to override the output for individual HTML components, `options.react` gives you complete flexibility to return any React component you want for each Markdown rule (`text`, `codeBlock`...). This is useful if you're trying to add custom syntatical sugar to some Markdown type. All the rules are defined on the [`compiler` function](index.js#743), and you can take a look at what arguments the `react()` method expects. For example, the `codeBlock` rule is:
 

--- a/README.md
+++ b/README.md
@@ -342,9 +342,9 @@ import { render } from 'react-dom';
 const md = `
 # Custom code block
 
-\`\`\`html
+`` `html
 <h1>Hey!</h1>
-\`\`\`
+`` `
 `;
 
 render(

--- a/index.js
+++ b/index.js
@@ -1354,6 +1354,17 @@ export function compiler(markdown, options) {
     }
   };
 
+  // Overwrite default react functions with options
+  Object.keys(options.react).forEach(key => {
+    const original = rules[key];
+
+    if (!original) {
+      return;
+    }
+
+    original.react = options.react[key];
+  });
+
   // Object.keys(rules).forEach(key => {
   //     let parse = rules[key].parse;
 

--- a/index.js
+++ b/index.js
@@ -9,48 +9,48 @@ import unquote from 'unquote';
 
 /** TODO: Drop for React 16? */
 const ATTRIBUTE_TO_JSX_PROP_MAP = {
-    'accesskey': 'accessKey',
-    'allowfullscreen': 'allowFullScreen',
-    'allowtransparency': 'allowTransparency',
-    'autocomplete': 'autoComplete',
-    'autofocus': 'autoFocus',
-    'autoplay': 'autoPlay',
-    'cellpadding': 'cellPadding',
-    'cellspacing': 'cellSpacing',
-    'charset': 'charSet',
-    'class': 'className',
-    'classid': 'classId',
-    'colspan': 'colSpan',
-    'contenteditable': 'contentEditable',
-    'contextmenu': 'contextMenu',
-    'crossorigin': 'crossOrigin',
-    'enctype': 'encType',
-    'for': 'htmlFor',
-    'formaction': 'formAction',
-    'formenctype': 'formEncType',
-    'formmethod': 'formMethod',
-    'formnovalidate': 'formNoValidate',
-    'formtarget': 'formTarget',
-    'frameborder': 'frameBorder',
-    'hreflang': 'hrefLang',
-    'inputmode': 'inputMode',
-    'keyparams': 'keyParams',
-    'keytype': 'keyType',
-    'marginheight': 'marginHeight',
-    'marginwidth': 'marginWidth',
-    'maxlength': 'maxLength',
-    'mediagroup': 'mediaGroup',
-    'minlength': 'minLength',
-    'novalidate': 'noValidate',
-    'radiogroup': 'radioGroup',
-    'readonly': 'readOnly',
-    'rowspan': 'rowSpan',
-    'spellcheck': 'spellCheck',
-    'srcdoc': 'srcDoc',
-    'srclang': 'srcLang',
-    'srcset': 'srcSet',
-    'tabindex': 'tabIndex',
-    'usemap': 'useMap',
+  accesskey: 'accessKey',
+  allowfullscreen: 'allowFullScreen',
+  allowtransparency: 'allowTransparency',
+  autocomplete: 'autoComplete',
+  autofocus: 'autoFocus',
+  autoplay: 'autoPlay',
+  cellpadding: 'cellPadding',
+  cellspacing: 'cellSpacing',
+  charset: 'charSet',
+  class: 'className',
+  classid: 'classId',
+  colspan: 'colSpan',
+  contenteditable: 'contentEditable',
+  contextmenu: 'contextMenu',
+  crossorigin: 'crossOrigin',
+  enctype: 'encType',
+  for: 'htmlFor',
+  formaction: 'formAction',
+  formenctype: 'formEncType',
+  formmethod: 'formMethod',
+  formnovalidate: 'formNoValidate',
+  formtarget: 'formTarget',
+  frameborder: 'frameBorder',
+  hreflang: 'hrefLang',
+  inputmode: 'inputMode',
+  keyparams: 'keyParams',
+  keytype: 'keyType',
+  marginheight: 'marginHeight',
+  marginwidth: 'marginWidth',
+  maxlength: 'maxLength',
+  mediagroup: 'mediaGroup',
+  minlength: 'minLength',
+  novalidate: 'noValidate',
+  radiogroup: 'radioGroup',
+  readonly: 'readOnly',
+  rowspan: 'rowSpan',
+  spellcheck: 'spellCheck',
+  srcdoc: 'srcDoc',
+  srclang: 'srcLang',
+  srcset: 'srcSet',
+  tabindex: 'tabIndex',
+  usemap: 'useMap'
 };
 
 /**
@@ -181,152 +181,164 @@ const LIST_ITEM_PREFIX_R = new RegExp('^' + LIST_ITEM_PREFIX);
 //
 //  * but this is not part of the same item
 const LIST_ITEM_R = new RegExp(
-    LIST_ITEM_PREFIX +
+  LIST_ITEM_PREFIX +
     '[^\\n]*(?:\\n' +
-    '(?!\\1' + LIST_BULLET + ' )[^\\n]*)*(\\n|$)',
-    'gm'
+    '(?!\\1' +
+    LIST_BULLET +
+    ' )[^\\n]*)*(\\n|$)',
+  'gm'
 );
 
 // check whether a list item has paragraphs: if it does,
 // we leave the newlines at the end
 const LIST_R = new RegExp(
-    '^( *)(' + LIST_BULLET + ') ' +
+  '^( *)(' +
+    LIST_BULLET +
+    ') ' +
     '[\\s\\S]+?(?:\\n{2,}(?! )' +
-    '(?!\\1' + LIST_BULLET + ' )\\n*' +
+    '(?!\\1' +
+    LIST_BULLET +
+    ' )\\n*' +
     // the \\s*$ here is so that we can parse the inside of nested
     // lists, where our content might end before we receive two `\n`s
     '|\\s*\\n*$)'
 );
 
 const LINK_INSIDE = '(?:\\[[^\\]]*\\]|[^\\[\\]]|\\](?=[^\\[]*\\]))*';
-const LINK_HREF_AND_TITLE = '\\s*<?((?:[^\\s\\\\]|\\\\.)*?)>?(?:\\s+[\'"]([\\s\\S]*?)[\'"])?\\s*';
+const LINK_HREF_AND_TITLE =
+  '\\s*<?((?:[^\\s\\\\]|\\\\.)*?)>?(?:\\s+[\'"]([\\s\\S]*?)[\'"])?\\s*';
 
 const LINK_R = new RegExp(
-    '^\\[(' + LINK_INSIDE + ')\\]\\(' + LINK_HREF_AND_TITLE + '\\)'
+  '^\\[(' + LINK_INSIDE + ')\\]\\(' + LINK_HREF_AND_TITLE + '\\)'
 );
 
 const IMAGE_R = new RegExp(
-    '^!\\[(' + LINK_INSIDE + ')\\]\\(' + LINK_HREF_AND_TITLE + '\\)'
+  '^!\\[(' + LINK_INSIDE + ')\\]\\(' + LINK_HREF_AND_TITLE + '\\)'
 );
 
-function parseTableAlignCapture (alignCapture) {
-    if (TABLE_RIGHT_ALIGN.test(alignCapture)) {
-        return 'right';
-    } else if (TABLE_CENTER_ALIGN.test(alignCapture)) {
-        return 'center';
-    } else if (TABLE_LEFT_ALIGN.test(alignCapture)) {
-        return 'left';
-    }
+function parseTableAlignCapture(alignCapture) {
+  if (TABLE_RIGHT_ALIGN.test(alignCapture)) {
+    return 'right';
+  } else if (TABLE_CENTER_ALIGN.test(alignCapture)) {
+    return 'center';
+  } else if (TABLE_LEFT_ALIGN.test(alignCapture)) {
+    return 'left';
+  }
 
-    return null;
+  return null;
 }
 
-function parseTableHeader (capture, parse, state) {
-    const headerText = capture[1]
-        .replace(TABLE_TRIM_PIPES, '')
-        .trim()
-        .split(TABLE_ROW_SPLIT);
+function parseTableHeader(capture, parse, state) {
+  const headerText = capture[1]
+    .replace(TABLE_TRIM_PIPES, '')
+    .trim()
+    .split(TABLE_ROW_SPLIT);
 
-    return headerText.map(function (text) { return parse(text, state); });
+  return headerText.map(function(text) {
+    return parse(text, state);
+  });
 }
 
-function parseTableAlign (capture/*, parse, state*/) {
-    const alignText = capture[2]
-        .replace(TABLE_TRIM_PIPES, '')
-        .trim()
-        .split(TABLE_ROW_SPLIT);
+function parseTableAlign(capture /*, parse, state*/) {
+  const alignText = capture[2]
+    .replace(TABLE_TRIM_PIPES, '')
+    .trim()
+    .split(TABLE_ROW_SPLIT);
 
-    return alignText.map(parseTableAlignCapture);
+  return alignText.map(parseTableAlignCapture);
 }
 
-function parseTableCells (capture, parse, state) {
-    const rowsText = capture[3]
-        .replace(TABLE_TRIM_PIPES, '')
-        .trim()
-        .split('\n');
+function parseTableCells(capture, parse, state) {
+  const rowsText = capture[3]
+    .replace(TABLE_TRIM_PIPES, '')
+    .trim()
+    .split('\n');
 
-    return rowsText.map(function (rowText) {
-        return rowText.replace(TABLE_TRIM_PIPES, '').split(TABLE_ROW_SPLIT).map(function (text) {
-            return parse(text.trim(), state);
-        });
-    });
+  return rowsText.map(function(rowText) {
+    return rowText
+      .replace(TABLE_TRIM_PIPES, '')
+      .split(TABLE_ROW_SPLIT)
+      .map(function(text) {
+        return parse(text.trim(), state);
+      });
+  });
 }
 
-function parseTable (capture, parse, state) {
-    state.inline = true;
-    const header = parseTableHeader(capture, parse, state);
-    const align = parseTableAlign(capture, parse, state);
-    const cells = parseTableCells(capture, parse, state);
-    state.inline = false;
+function parseTable(capture, parse, state) {
+  state.inline = true;
+  const header = parseTableHeader(capture, parse, state);
+  const align = parseTableAlign(capture, parse, state);
+  const cells = parseTableCells(capture, parse, state);
+  state.inline = false;
 
-    return {
-        align: align,
-        cells: cells,
-        header: header,
-        type: 'table',
-    };
+  return {
+    align: align,
+    cells: cells,
+    header: header,
+    type: 'table'
+  };
 }
 
-function getTableStyle (node, colIndex) {
-    return node.align[colIndex] == null ? {} : {
-        textAlign: node.align[colIndex],
-    };
+function getTableStyle(node, colIndex) {
+  return node.align[colIndex] == null
+    ? {}
+    : {
+        textAlign: node.align[colIndex]
+      };
 }
 
 /** TODO: remove for react 16 */
-function normalizeAttributeKey (key) {
-    const hyphenIndex = key.indexOf('-');
+function normalizeAttributeKey(key) {
+  const hyphenIndex = key.indexOf('-');
 
-    if (hyphenIndex !== -1 && key.match(HTML_CUSTOM_ATTR_R) === null) {
-        key = key.replace(CAPTURE_LETTER_AFTER_HYPHEN, function (_, letter) { return letter.toUpperCase(); });
-    }
+  if (hyphenIndex !== -1 && key.match(HTML_CUSTOM_ATTR_R) === null) {
+    key = key.replace(CAPTURE_LETTER_AFTER_HYPHEN, function(_, letter) {
+      return letter.toUpperCase();
+    });
+  }
 
-    return key;
+  return key;
 }
 
-function isInterpolation (value) {
-    return INTERPOLATION_R.test(value);
+function isInterpolation(value) {
+  return INTERPOLATION_R.test(value);
 }
 
-function attributeValueToJSXPropValue (key, value) {
-    if (key === 'style') {
-        return value.split(/;\s?/).reduce(function (styles, kvPair) {
+function attributeValueToJSXPropValue(key, value) {
+  if (key === 'style') {
+    return value.split(/;\s?/).reduce(function(styles, kvPair) {
+      const key = kvPair.slice(0, kvPair.indexOf(':'));
 
-            const key = kvPair.slice(0, kvPair.indexOf(':'));
+      // snake-case to camelCase
+      // also handles PascalCasing vendor prefixes
+      const camelCasedKey = key.replace(/(-[a-z])/g, function toUpper(substr) {
+        return substr[1].toUpperCase();
+      });
 
-            // snake-case to camelCase
-            // also handles PascalCasing vendor prefixes
-            const camelCasedKey = key.replace(/(-[a-z])/g, function toUpper (substr) {
-                return substr[1].toUpperCase();
-            });
+      // key.length + 1 to skip over the colon
+      styles[camelCasedKey] = kvPair.slice(key.length + 1).trim();
 
-            // key.length + 1 to skip over the colon
-            styles[camelCasedKey] = kvPair.slice(key.length + 1).trim();
+      return styles;
+    }, {});
+  } else if (isInterpolation(value)) {
+    // return as a string and let the consumer decide what to do with it
+    value = value.slice(1, value.length - 1);
+  }
 
-            return styles;
+  if (value === 'true') {
+    return true;
+  } else if (value === 'false') {
+    return false;
+  }
 
-        }, {});
-
-    } else if (isInterpolation(value)) {
-        // return as a string and let the consumer decide what to do with it
-        value = value.slice(1, value.length - 1);
-    }
-
-    if (value === 'true') {
-        return true;
-    } else if (value === 'false') {
-        return false;
-    }
-
-    return value;
+  return value;
 }
 
-function normalizeWhitespace (source) {
-    return source
-        .replace(CR_NEWLINE_R, '\n')
-        .replace(FORMFEED_R, '')
-        .replace(TAB_R, '    ')
-    ;
+function normalizeWhitespace(source) {
+  return source
+    .replace(CR_NEWLINE_R, '\n')
+    .replace(FORMFEED_R, '')
+    .replace(TAB_R, '    ');
 }
 
 /**
@@ -348,233 +360,237 @@ function normalizeWhitespace (source) {
  *     some nesting is. For an example use-case, see passage-ref
  *     parsing in src/widgets/passage/passage-markdown.jsx
  */
-function parserFor (rules) {
-    // Sorts rules in order of increasing order, then
-    // ascending rule name in case of ties.
-    let ruleList = Object.keys(rules);
+function parserFor(rules) {
+  // Sorts rules in order of increasing order, then
+  // ascending rule name in case of ties.
+  let ruleList = Object.keys(rules);
 
-    /* istanbul ignore next */
-    if (process.env.NODE_ENV !== 'production') {
-        ruleList.forEach(function (type) {
-            let order = rules[type].order;
-            if (
-                process.env.NODE_ENV !== 'production'
-                && (typeof order !== 'number' || !isFinite(order))
-                && typeof console !== 'undefined'
-            ) {
-                console.warn(
-                    'markdown-to-jsx: Invalid order for rule `' + type + '`: ' +
-                    order
-                );
-            }
-        });
-    }
-
-    ruleList.sort(function (typeA, typeB) {
-        let orderA = rules[typeA].order;
-        let orderB = rules[typeB].order;
-
-        // First sort based on increasing order
-        if (orderA !== orderB) {
-            return orderA - orderB;
-
-        // Then based on increasing unicode lexicographic ordering
-        } else if (typeA < typeB) {
-            return -1;
-        }
-
-        return 1;
+  /* istanbul ignore next */
+  if (process.env.NODE_ENV !== 'production') {
+    ruleList.forEach(function(type) {
+      let order = rules[type].order;
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        (typeof order !== 'number' || !isFinite(order)) &&
+        typeof console !== 'undefined'
+      ) {
+        console.warn(
+          'markdown-to-jsx: Invalid order for rule `' + type + '`: ' + order
+        );
+      }
     });
+  }
 
-    function nestedParse (source, state) {
-        let result = [];
+  ruleList.sort(function(typeA, typeB) {
+    let orderA = rules[typeA].order;
+    let orderB = rules[typeB].order;
 
-        // We store the previous capture so that match functions can
-        // use some limited amount of lookbehind. Lists use this to
-        // ensure they don't match arbitrary '- ' or '* ' in inline
-        // text (see the list rule for more information).
-        let prevCapture = '';
-        while (source) {
-            let i = 0;
-            while (i < ruleList.length) {
-                const ruleType = ruleList[i];
-                const rule = rules[ruleType];
-                const capture = rule.match(source, state, prevCapture);
+    // First sort based on increasing order
+    if (orderA !== orderB) {
+      return orderA - orderB;
 
-                if (capture) {
-                    const currCaptureString = capture[0];
-                    source = source.substring(currCaptureString.length);
-                    const parsed = rule.parse(capture, nestedParse, state);
-
-                    // We also let rules override the default type of
-                    // their parsed node if they would like to, so that
-                    // there can be a single output function for all links,
-                    // even if there are several rules to parse them.
-                    if (parsed.type == null) {
-                        parsed.type = ruleType;
-                    }
-
-                    result.push(parsed);
-
-                    prevCapture = currCaptureString;
-                    break;
-                }
-
-                i++;
-            }
-        }
-
-        return result;
+      // Then based on increasing unicode lexicographic ordering
+    } else if (typeA < typeB) {
+      return -1;
     }
 
-    return function outerParse (source, state) {
-        return nestedParse(normalizeWhitespace(source), state);
-    };
+    return 1;
+  });
+
+  function nestedParse(source, state) {
+    let result = [];
+
+    // We store the previous capture so that match functions can
+    // use some limited amount of lookbehind. Lists use this to
+    // ensure they don't match arbitrary '- ' or '* ' in inline
+    // text (see the list rule for more information).
+    let prevCapture = '';
+    while (source) {
+      let i = 0;
+      while (i < ruleList.length) {
+        const ruleType = ruleList[i];
+        const rule = rules[ruleType];
+        const capture = rule.match(source, state, prevCapture);
+
+        if (capture) {
+          const currCaptureString = capture[0];
+          source = source.substring(currCaptureString.length);
+          const parsed = rule.parse(capture, nestedParse, state);
+
+          // We also let rules override the default type of
+          // their parsed node if they would like to, so that
+          // there can be a single output function for all links,
+          // even if there are several rules to parse them.
+          if (parsed.type == null) {
+            parsed.type = ruleType;
+          }
+
+          result.push(parsed);
+
+          prevCapture = currCaptureString;
+          break;
+        }
+
+        i++;
+      }
+    }
+
+    return result;
+  }
+
+  return function outerParse(source, state) {
+    return nestedParse(normalizeWhitespace(source), state);
+  };
 }
 
 // Creates a match function for an inline scoped element from a regex
-function inlineRegex (regex) {
-    return function match (source, state) {
-        if (state.inline) {
-            return regex.exec(source);
-        } else {
-            return null;
-        }
-    };
+function inlineRegex(regex) {
+  return function match(source, state) {
+    if (state.inline) {
+      return regex.exec(source);
+    } else {
+      return null;
+    }
+  };
 }
 
 // Creates a match function for a block scoped element from a regex
-function blockRegex (regex) {
-    return function match (source, state) {
-        if (state.inline) {
-            return null;
-        } else {
-            return regex.exec(source);
-        }
-    };
+function blockRegex(regex) {
+  return function match(source, state) {
+    if (state.inline) {
+      return null;
+    } else {
+      return regex.exec(source);
+    }
+  };
 }
 
 // Creates a match function from a regex, ignoring block/inline scope
-function anyScopeRegex (regex) {
-    return function match (source/*, state*/) {
-        return regex.exec(source);
-    };
+function anyScopeRegex(regex) {
+  return function match(source /*, state*/) {
+    return regex.exec(source);
+  };
 }
 
-function reactFor (outputFunc) {
-    return function nestedReactOutput (ast, state) {
-        state = state || {};
-        if (Array.isArray(ast)) {
-            const oldKey = state.key;
-            const result = [];
+function reactFor(outputFunc) {
+  return function nestedReactOutput(ast, state) {
+    state = state || {};
+    if (Array.isArray(ast)) {
+      const oldKey = state.key;
+      const result = [];
 
-            // map nestedOutput over the ast, except group any text
-            // nodes together into a single string output.
-            let lastWasString = false;
+      // map nestedOutput over the ast, except group any text
+      // nodes together into a single string output.
+      let lastWasString = false;
 
-            for (let i = 0; i < ast.length; i++) {
-                state.key = i;
+      for (let i = 0; i < ast.length; i++) {
+        state.key = i;
 
-                const nodeOut = nestedReactOutput(ast[i], state);
-                const isString = typeof nodeOut === 'string';
+        const nodeOut = nestedReactOutput(ast[i], state);
+        const isString = typeof nodeOut === 'string';
 
-                if (isString && lastWasString) {
-                    result[result.length - 1] += nodeOut;
-                } else {
-                    result.push(nodeOut);
-                }
-
-                lastWasString = isString;
-            }
-
-            state.key = oldKey;
-
-            return result;
+        if (isString && lastWasString) {
+          result[result.length - 1] += nodeOut;
+        } else {
+          result.push(nodeOut);
         }
 
-        return outputFunc(ast, nestedReactOutput, state);
-    };
-}
+        lastWasString = isString;
+      }
 
-function sanitizeUrl (url) {
-    try {
-        const prot = decodeURIComponent(url)
-            .replace(/[^A-Z0-9/:]/gi, '')
-            .toLowerCase()
-        ;
+      state.key = oldKey;
 
-        if (prot.indexOf('javascript:') === 0) {
-            return null;
-        }
-    } catch (e) {
-        // decodeURIComponent sometimes throws a URIError
-        // See `decodeURIComponent('a%AFc');`
-        // http://stackoverflow.com/questions/9064536/javascript-decodeuricomponent-malformed-uri-exception
-        return null;
+      return result;
     }
 
-    return url;
+    return outputFunc(ast, nestedReactOutput, state);
+  };
 }
 
-function unescapeUrl (rawUrlString) {
-    return rawUrlString.replace(UNESCAPE_URL_R, '$1');
+function sanitizeUrl(url) {
+  try {
+    const prot = decodeURIComponent(url)
+      .replace(/[^A-Z0-9/:]/gi, '')
+      .toLowerCase();
+
+    if (prot.indexOf('javascript:') === 0) {
+      return null;
+    }
+  } catch (e) {
+    // decodeURIComponent sometimes throws a URIError
+    // See `decodeURIComponent('a%AFc');`
+    // http://stackoverflow.com/questions/9064536/javascript-decodeuricomponent-malformed-uri-exception
+    return null;
+  }
+
+  return url;
+}
+
+function unescapeUrl(rawUrlString) {
+  return rawUrlString.replace(UNESCAPE_URL_R, '$1');
 }
 
 // Parse some content with the parser `parse`, with state.inline
 // set to true. Useful for block elements; not generally necessary
 // to be used by inline elements (where state.inline is already true.
-function parseInline (parse, content, state) {
-    const isCurrentlyInline = state.inline || false;
-    state.inline = true;
-    const result = parse(content, state);
-    state.inline = isCurrentlyInline;
-    return result;
+function parseInline(parse, content, state) {
+  const isCurrentlyInline = state.inline || false;
+  state.inline = true;
+  const result = parse(content, state);
+  state.inline = isCurrentlyInline;
+  return result;
 }
 
-function parseBlock (parse, content, state) {
-    state.inline = false;
-    return parse(content + '\n\n', state);
+function parseBlock(parse, content, state) {
+  state.inline = false;
+  return parse(content + '\n\n', state);
 }
 
-function parseCaptureInline (capture, parse, state) {
-    return {
-        content: parseInline(parse, capture[1], state),
-    };
+function parseCaptureInline(capture, parse, state) {
+  return {
+    content: parseInline(parse, capture[1], state)
+  };
 }
 
-function captureNothing () { return {}; }
-function renderNothing () { return null; }
-
-function ruleOutput (rules) {
-    return function nestedRuleOutput (ast, outputFunc, state) {
-        return rules[ast.type].react(ast, outputFunc, state);
-    };
+function captureNothing() {
+  return {};
+}
+function renderNothing() {
+  return null;
 }
 
-function cx () {
-    return Array.prototype.slice.call(arguments).filter(Boolean).join(' ');
+function ruleOutput(rules) {
+  return function nestedRuleOutput(ast, outputFunc, state) {
+    return rules[ast.type].react(ast, outputFunc, state);
+  };
 }
 
-function get (src, path, fb) {
-    let ptr = src;
-    const frags = path.split('.');
-
-    while (frags.length) {
-        ptr = ptr[frags[0]];
-
-        if (ptr === undefined) break;
-        else frags.shift();
-    }
-
-    return ptr || fb;
+function cx() {
+  return Array.prototype.slice
+    .call(arguments)
+    .filter(Boolean)
+    .join(' ');
 }
 
-function getTag (tag, overrides) {
-    const override = get(overrides, tag);
-    return typeof override === 'function'
-        ? override
-        : get(overrides, `${tag}.component`, tag)
-    ;
+function get(src, path, fb) {
+  let ptr = src;
+  const frags = path.split('.');
+
+  while (frags.length) {
+    ptr = ptr[frags[0]];
+
+    if (ptr === undefined) break;
+    else frags.shift();
+  }
+
+  return ptr || fb;
+}
+
+function getTag(tag, overrides) {
+  const override = get(overrides, tag);
+  return typeof override === 'function'
+    ? override
+    : get(overrides, `${tag}.component`, tag);
 }
 
 /**
@@ -602,98 +618,111 @@ const PARSE_PRIORITY_LOW = 4;
  */
 const PARSE_PRIORITY_MIN = 5;
 
-export function compiler (markdown, options) {
-    options = options || {};
-    options.overrides = options.overrides || {};
+export function compiler(markdown, options) {
+  options = options || {};
+  options.overrides = options.overrides || {};
+  options.react = options.react || {};
 
-    // eslint-disable-next-line no-unused-vars
-    function h (tag, props, ...children) {
-        const overrideProps = get(options.overrides, `${tag}.props`, {});
-        return React.createElement(getTag(tag, options.overrides), {
-            ...overrideProps,
-            ...props,
-            className: cx(props && props.className, overrideProps.className) || undefined,
-        }, ...children);
+  // eslint-disable-next-line no-unused-vars
+  function h(tag, props, ...children) {
+    const overrideProps = get(options.overrides, `${tag}.props`, {});
+    return React.createElement(
+      getTag(tag, options.overrides),
+      {
+        ...overrideProps,
+        ...props,
+        className:
+          cx(props && props.className, overrideProps.className) || undefined
+      },
+      ...children
+    );
+  }
+
+  function compile(input) {
+    let inline = false;
+
+    if (options.forceInline) {
+      inline = true;
+    } else if (!options.forceBlock) {
+      /**
+       * should not contain any block-level markdown like newlines, lists, headings,
+       * thematic breaks, blockquotes, tables, etc
+       */
+      inline = /(\n|^[-*]\s|^#|^ {2,}|^-{2,}|^>\s)/g.test(input) === false;
     }
 
-    function compile (input) {
-        let inline = false;
+    const arr = emitter(
+      parser(
+        inline
+          ? input
+          : `${input.replace(TRIM_NEWLINES_AND_TRAILING_WHITESPACE_R, '')}\n\n`,
+        { inline }
+      )
+    );
 
-        if (options.forceInline) {
-            inline = true;
-        } else if (!options.forceBlock) {
-            /**
-            * should not contain any block-level markdown like newlines, lists, headings,
-            * thematic breaks, blockquotes, tables, etc
-            */
-            inline = /(\n|^[-*]\s|^#|^ {2,}|^-{2,}|^>\s)/g.test(input) === false;
-        }
+    let jsx;
+    if (arr.length > 1) {
+      jsx = inline ? <span>{arr}</span> : <div>{arr}</div>;
+    } else if (arr.length === 1) {
+      jsx = arr[0];
 
-        const arr = emitter(
-            parser(
-                inline
-                    ? input
-                    : `${input.replace(TRIM_NEWLINES_AND_TRAILING_WHITESPACE_R, '')}\n\n`
-                , { inline }
-            )
-        );
+      // TODO: remove this for React 16
+      if (typeof jsx === 'string') {
+        jsx = <span>{jsx}</span>;
+      }
+    } else {
+      // TODO: return null for React 16
+      jsx = <span />;
+    }
 
-        let jsx;
-        if (arr.length > 1) {
-            jsx = inline ? <span>{arr}</span> : <div>{arr}</div>;
-        } else if (arr.length === 1) {
-            jsx = arr[0];
+    return jsx;
+  }
 
-            // TODO: remove this for React 16
-            if (typeof jsx === 'string') {
-                jsx = <span>{jsx}</span>;
+  function attrStringToMap(str) {
+    const attributes = str.match(ATTR_EXTRACTOR_R);
+
+    return attributes
+      ? attributes.reduce(function(map, raw, index) {
+          const delimiterIdx = raw.indexOf('=');
+
+          if (delimiterIdx !== -1) {
+            const key = normalizeAttributeKey(raw.slice(0, delimiterIdx));
+            const value = unquote(raw.slice(delimiterIdx + 1));
+
+            const mappedKey = ATTRIBUTE_TO_JSX_PROP_MAP[key] || key;
+            const normalizedValue = (map[
+              mappedKey
+            ] = attributeValueToJSXPropValue(key, value));
+
+            if (
+              HTML_BLOCK_ELEMENT_R.test(normalizedValue) ||
+              HTML_SELF_CLOSING_ELEMENT_R.test(normalizedValue)
+            ) {
+              map[mappedKey] = React.cloneElement(
+                compile(normalizedValue.trim()),
+                { key: index }
+              );
             }
-        } else {
-            // TODO: return null for React 16
-            jsx = <span />;
-        }
+          } else {
+            map[ATTRIBUTE_TO_JSX_PROP_MAP[raw] || raw] = true;
+          }
 
-        return jsx;
-    }
+          return map;
+        }, {})
+      : undefined;
+  }
 
-    function attrStringToMap (str) {
-        const attributes = str.match(ATTR_EXTRACTOR_R);
-
-        return attributes ? attributes.reduce(function (map, raw, index) {
-            const delimiterIdx = raw.indexOf('=');
-
-            if (delimiterIdx !== -1) {
-                const key = normalizeAttributeKey(raw.slice(0, delimiterIdx));
-                const value = unquote(raw.slice(delimiterIdx + 1));
-
-                const mappedKey = ATTRIBUTE_TO_JSX_PROP_MAP[key] || key;
-                const normalizedValue = map[mappedKey] = attributeValueToJSXPropValue(key, value);
-
-                if (
-                    HTML_BLOCK_ELEMENT_R.test(normalizedValue)
-                    || HTML_SELF_CLOSING_ELEMENT_R.test(normalizedValue)
-                ) {
-                    map[mappedKey] = React.cloneElement(
-                        compile(normalizedValue.trim()), { key: index }
-                    );
-                }
-            } else {
-                map[ATTRIBUTE_TO_JSX_PROP_MAP[raw] || raw] = true;
-            }
-
-            return map;
-        }, {}) : undefined;
-    }
-
-    /* istanbul ignore next */
-    if (process.env.NODE_ENV !== 'production') {
-        if (typeof markdown !== 'string') {
-            throw new Error(`markdown-to-jsx: the first argument must be
+  /* istanbul ignore next */
+  if (process.env.NODE_ENV !== 'production') {
+    if (typeof markdown !== 'string') {
+      throw new Error(`markdown-to-jsx: the first argument must be
                              a string`);
-        }
+    }
 
-        if (Object.prototype.toString.call(options.overrides) !== '[object Object]') {
-            throw new Error(`markdown-to-jsx: options.overrides (second argument property) must be
+    if (
+      Object.prototype.toString.call(options.overrides) !== '[object Object]'
+    ) {
+      throw new Error(`markdown-to-jsx: options.overrides (second argument property) must be
                              undefined or an object literal with shape:
                              {
                                 htmltagname: {
@@ -701,696 +730,660 @@ export function compiler (markdown, options) {
                                     props: object(optional)
                                 }
                              }`);
-        }
     }
+  }
 
-    const footnotes = [];
-    const refs = {};
+  const footnotes = [];
+  const refs = {};
+
+  /**
+   * each rule's react() output function goes through our custom h() JSX pragma;
+   * this allows the override functionality to be automatically applied
+   */
+  const rules = {
+    blockQuote: {
+      match: blockRegex(BLOCKQUOTE_R),
+      order: PARSE_PRIORITY_HIGH,
+      parse(capture, parse, state) {
+        return {
+          content: parse(
+            capture[0].replace(BLOCKQUOTE_TRIM_LEFT_MULTILINE_R, ''),
+            state
+          )
+        };
+      },
+      react(node, output, state) {
+        return (
+          <blockquote key={state.key}>{output(node.content, state)}</blockquote>
+        );
+      }
+    },
+
+    breakLine: {
+      match: anyScopeRegex(BREAK_LINE_R),
+      order: PARSE_PRIORITY_HIGH,
+      parse: captureNothing,
+      react(_, __, state) {
+        return <br key={state.key} />;
+      }
+    },
+
+    breakThematic: {
+      match: blockRegex(BREAK_THEMATIC_R),
+      order: PARSE_PRIORITY_HIGH,
+      parse: captureNothing,
+      react(_, __, state) {
+        return <hr key={state.key} />;
+      }
+    },
+
+    codeBlock: {
+      match: blockRegex(CODE_BLOCK_R),
+      order: PARSE_PRIORITY_MAX,
+      parse(capture /*, parse, state*/) {
+        let content = capture[0].replace(/^ {4}/gm, '').replace(/\n+$/, '');
+        return {
+          content: content,
+          lang: undefined
+        };
+      },
+
+      react(node, output, state) {
+        return (
+          <pre key={state.key}>
+            <code className={node.lang ? `lang-${node.lang}` : ''}>
+              {node.content}
+            </code>
+          </pre>
+        );
+      }
+    },
+
+    codeFenced: {
+      match: blockRegex(CODE_BLOCK_FENCED_R),
+      order: PARSE_PRIORITY_MAX,
+      parse(capture /*, parse, state*/) {
+        return {
+          content: capture[3],
+          lang: capture[2] || undefined,
+          type: 'codeBlock'
+        };
+      }
+    },
+
+    codeInline: {
+      match: inlineRegex(CODE_INLINE_R),
+      order: PARSE_PRIORITY_LOW,
+      parse(capture /*, parse, state*/) {
+        return {
+          content: capture[2]
+        };
+      },
+      react(node, output, state) {
+        return <code key={state.key}>{node.content}</code>;
+      }
+    },
 
     /**
-     * each rule's react() output function goes through our custom h() JSX pragma;
-     * this allows the override functionality to be automatically applied
+     * footnotes are emitted at the end of compilation in a special <footer> block
      */
-    const rules = {
-        blockQuote: {
-            match: blockRegex(BLOCKQUOTE_R),
-            order: PARSE_PRIORITY_HIGH,
-            parse (capture, parse, state) {
-                return {
-                    content: parse(capture[0].replace(BLOCKQUOTE_TRIM_LEFT_MULTILINE_R, ''), state),
-                };
-            },
-            react (node, output, state) {
-                return (
-                    <blockquote key={state.key}>
-                        {output(node.content, state)}
-                    </blockquote>
-                );
-            },
-        },
+    footnote: {
+      match: blockRegex(FOOTNOTE_R),
+      order: PARSE_PRIORITY_MAX,
+      parse(capture /*, parse, state*/) {
+        footnotes.push({
+          footnote: capture[2],
+          identifier: capture[1]
+        });
 
-        breakLine: {
-            match: anyScopeRegex(BREAK_LINE_R),
-            order: PARSE_PRIORITY_HIGH,
-            parse: captureNothing,
-            react (_, __, state) {
-                return (
-                    <br key={state.key} />
-                );
-            },
-        },
+        return {};
+      },
+      react: renderNothing
+    },
 
-        breakThematic: {
-            match: blockRegex(BREAK_THEMATIC_R),
-            order: PARSE_PRIORITY_HIGH,
-            parse: captureNothing,
-            react (_, __, state) {
-                return (
-                    <hr key={state.key} />
-                );
-            },
-        },
-
-        codeBlock: {
-            match: blockRegex(CODE_BLOCK_R),
-            order: PARSE_PRIORITY_MAX,
-            parse (capture/*, parse, state*/) {
-                let content = capture[0]
-                    .replace(/^ {4}/gm, '')
-                    .replace(/\n+$/, '');
-                return {
-                    content: content,
-                    lang: undefined,
-                };
-            },
-
-            react (node, output, state) {
-                return (
-                    <pre key={state.key}>
-                        <code className={node.lang ? `lang-${node.lang}` : ''}>
-                            {node.content}
-                        </code>
-                    </pre>
-                );
-            },
-        },
-
-        codeFenced: {
-            match: blockRegex(CODE_BLOCK_FENCED_R),
-            order: PARSE_PRIORITY_MAX,
-            parse (capture/*, parse, state*/) {
-                return {
-                    content: capture[3],
-                    lang: capture[2] || undefined,
-                    type: 'codeBlock',
-                };
-            },
-        },
-
-        codeInline: {
-            match: inlineRegex(CODE_INLINE_R),
-            order: PARSE_PRIORITY_LOW,
-            parse (capture/*, parse, state*/) {
-                return {
-                    content: capture[2],
-                };
-            },
-            react (node, output, state) {
-                return (
-                    <code key={state.key}>
-                        {node.content}
-                    </code>
-                );
-            },
-        },
-
-        /**
-         * footnotes are emitted at the end of compilation in a special <footer> block
-         */
-        footnote: {
-            match: blockRegex(FOOTNOTE_R),
-            order: PARSE_PRIORITY_MAX,
-            parse (capture/*, parse, state*/) {
-                footnotes.push({
-                    footnote: capture[2],
-                    identifier: capture[1],
-                });
-
-                return {};
-            },
-            react: renderNothing,
-        },
-
-        footnoteReference: {
-            match: inlineRegex(FOOTNOTE_REFERENCE_R),
-            order: PARSE_PRIORITY_HIGH,
-            parse (capture/*, parse*/) {
-                return {
-                    content: capture[1],
-                    target: `#${capture[1]}`,
-                };
-            },
-            react (node, output, state) {
-                return (
-                    <a key={state.key} href={sanitizeUrl(node.target)}>
-                        <sup key={state.key}>
-                            {node.content}
-                        </sup>
-                    </a>
-                );
-            },
-        },
-
-        gfmTask: {
-            match: inlineRegex(GFM_TASK_R),
-            order: PARSE_PRIORITY_HIGH,
-            parse (capture/*, parse, state*/) {
-                return {
-                    completed: capture[1].toLowerCase() === 'x',
-                };
-            },
-            react (node, output, state) {
-                return (
-                    <input
-                        checked={node.completed}
-                        key={state.key}
-                        readOnly
-                        type="checkbox"
-                    />
-                );
-            },
-        },
-
-        heading: {
-            match: blockRegex(HEADING_R),
-            order: PARSE_PRIORITY_HIGH,
-            parse (capture, parse, state) {
-                return {
-                    content: parseInline(parse, capture[2], state),
-                    level: capture[1].length,
-                };
-            },
-            react (node, output, state) {
-                const Tag = `h${node.level}`;
-                return (
-                    <Tag key={state.key}>
-                        {output(node.content, state)}
-                    </Tag>
-                );
-            },
-        },
-
-        headingSetext: {
-            match: blockRegex(HEADING_SETEXT_R),
-            order: PARSE_PRIORITY_MAX,
-            parse (capture, parse, state) {
-                return {
-                    content: parseInline(parse, capture[1], state),
-                    level: capture[2] === '=' ? 1 : 2,
-                    type: 'heading',
-                };
-            },
-        },
-
-        htmlBlock: {
-            /**
-             * find the first matching end tag and process the interior
-             */
-            match: anyScopeRegex(HTML_BLOCK_ELEMENT_R),
-            order: PARSE_PRIORITY_HIGH,
-            parse (capture, parse, state) {
-                const parseFunc = capture[3].match(HTML_BLOCK_ELEMENT_R) ? parseBlock : parseInline;
-
-                return {
-                    attrs: attrStringToMap(capture[2]),
-                    /**
-                     * if another html block is detected within, parse as block,
-                     * otherwise parse as inline to pick up any further markdown
-                     */
-                    content: parseFunc(parse, capture[3].trim(), state),
-
-                    tag: capture[1],
-                };
-            },
-            react (node, output, state) {
-                return (
-                    <node.tag key={state.key} {...node.attrs}>
-                        {output(node.content, state)}
-                    </node.tag>
-                );
-            },
-        },
-
-        htmlComment: {
-            match: anyScopeRegex(HTML_COMMENT_R),
-            order: PARSE_PRIORITY_HIGH,
-            parse () { return {}; },
-            react: renderNothing,
-        },
-
-        htmlSelfClosing: {
-            /**
-             * find the first matching end tag and process the interior
-             */
-            match: anyScopeRegex(HTML_SELF_CLOSING_ELEMENT_R),
-            order: PARSE_PRIORITY_HIGH,
-            parse (capture/*, parse, state*/) {
-                return {
-                    attrs: attrStringToMap(capture[2]),
-                    tag: capture[1],
-                };
-            },
-            react (node, output, state) {
-                return (
-                    <node.tag
-                        {...node.attrs}
-                        key={state.key}
-                    />
-                );
-            },
-        },
-
-        image: {
-            match: inlineRegex(IMAGE_R),
-            order: PARSE_PRIORITY_HIGH,
-            parse (capture/*, parse, state*/) {
-                return {
-                    alt: capture[1],
-                    target: unescapeUrl(capture[2]),
-                    title: capture[3],
-                };
-            },
-            react (node, output, state) {
-                return (
-                    <img
-                        key={state.key}
-                        alt={node.alt || undefined}
-                        title={node.title || undefined}
-                        src={sanitizeUrl(node.target)}
-                    />
-                );
-            },
-        },
-
-        link: {
-            match: inlineRegex(LINK_R),
-            order: PARSE_PRIORITY_LOW,
-            parse (capture, parse, state) {
-                return {
-                    content: parse(capture[1], state),
-                    target: unescapeUrl(capture[2]),
-                    title: capture[3],
-                };
-            },
-            react (node, output, state) {
-                return (
-                    <a
-                        key={state.key}
-                        href={sanitizeUrl(node.target)}
-                        title={node.title}
-                    >
-                        {output(node.content, state)}
-                    </a>
-                );
-            },
-        },
-
-        // https://daringfireball.net/projects/markdown/syntax#autolink
-        linkAngleBraceStyleDetector: {
-            match: inlineRegex(LINK_AUTOLINK_R),
-            order: PARSE_PRIORITY_MAX,
-            parse (capture/*, parse, state*/) {
-                return {
-                    content: [{
-                        content: capture[1],
-                        type: 'text',
-                    }],
-                    target: capture[1],
-                    type: 'link',
-                };
-            },
-        },
-
-        linkBareUrlDetector: {
-            match: inlineRegex(LINK_AUTOLINK_BARE_URL_R),
-            order: PARSE_PRIORITY_MAX,
-            parse (capture/*, parse, state*/) {
-                return {
-                    content: [{
-                        content: capture[1],
-                        type: 'text',
-                    }],
-                    target: capture[1],
-                    title: undefined,
-                    type: 'link',
-                };
-            },
-        },
-
-        linkMailtoDetector: {
-            match: inlineRegex(LINK_AUTOLINK_MAILTO_R),
-            order: PARSE_PRIORITY_MAX,
-            parse (capture/*, parse, state*/) {
-                let address = capture[1];
-                let target = capture[1];
-
-                // Check for a `mailto:` already existing in the link:
-                if (!AUTOLINK_MAILTO_CHECK_R.test(target)) {
-                    target = 'mailto:' + target;
-                }
-
-                return {
-                    content: [{
-                        content: address.replace('mailto:', ''),
-                        type: 'text',
-                    }],
-                    target: target,
-                    type: 'link',
-                };
-            },
-        },
-
-        list: {
-            match (source, state, prevCapture) {
-                // We only want to break into a list if we are at the start of a
-                // line. This is to avoid parsing "hi * there" with "* there"
-                // becoming a part of a list.
-                // You might wonder, "but that's inline, so of course it wouldn't
-                // start a list?". You would be correct! Except that some of our
-                // lists can be inline, because they might be inside another list,
-                // in which case we can parse with inline scope, but need to allow
-                // nested lists inside this inline scope.
-                const isStartOfLine = LIST_LOOKBEHIND_R.test(prevCapture);
-                const isListBlock = state._list || !state.inline;
-
-                if (isStartOfLine && isListBlock) {
-                    return LIST_R.exec(source);
-                } else {
-                    return null;
-                }
-            },
-            order: PARSE_PRIORITY_HIGH,
-            parse (capture, parse, state) {
-                const bullet = capture[2];
-                const ordered = bullet.length > 1;
-                const start = ordered ? +bullet : undefined;
-                const items = capture[0]
-                    // recognize the end of a paragraph block inside a list item:
-                    // two or more newlines at end end of the item
-                    .replace(BLOCK_END_R, '\n')
-                    .match(LIST_ITEM_R);
-
-                let lastItemWasAParagraph = false;
-                const itemContent = items.map(function (item, i) {
-                    // We need to see how far indented this item is:
-                    const space = LIST_ITEM_PREFIX_R.exec(item)[0].length;
-
-                    // And then we construct a regex to "unindent" the subsequent
-                    // lines of the items by that amount:
-                    const spaceRegex = new RegExp('^ {1,' + space + '}', 'gm');
-
-                    // Before processing the item, we need a couple things
-                    const content = item
-                        // remove indents on trailing lines:
-                        .replace(spaceRegex, '')
-                        // remove the bullet:
-                        .replace(LIST_ITEM_PREFIX_R, '');
-
-                    // Handling "loose" lists, like:
-                    //
-                    //  * this is wrapped in a paragraph
-                    //
-                    //  * as is this
-                    //
-                    //  * as is this
-                    const isLastItem = (i === items.length - 1);
-                    const containsBlocks = content.indexOf('\n\n') !== -1;
-
-                    // Any element in a list is a block if it contains multiple
-                    // newlines. The last element in the list can also be a block
-                    // if the previous item in the list was a block (this is
-                    // because non-last items in the list can end with \n\n, but
-                    // the last item can't, so we just "inherit" this property
-                    // from our previous element).
-                    const thisItemIsAParagraph = containsBlocks ||
-                            (isLastItem && lastItemWasAParagraph);
-                    lastItemWasAParagraph = thisItemIsAParagraph;
-
-                    // backup our state for restoration afterwards. We're going to
-                    // want to set state._list to true, and state.inline depending
-                    // on our list's looseness.
-                    const oldStateInline = state.inline;
-                    const oldStateList = state._list;
-                    state._list = true;
-
-                    // Parse inline if we're in a tight list, or block if we're in
-                    // a loose list.
-                    let adjustedContent;
-                    if (thisItemIsAParagraph) {
-                        state.inline = false;
-                        adjustedContent = content.replace(LIST_ITEM_END_R, '\n\n');
-                    } else {
-                        state.inline = true;
-                        adjustedContent = content.replace(LIST_ITEM_END_R, '');
-                    }
-
-                    const result = parse(adjustedContent, state);
-
-                    // Restore our state before returning
-                    state.inline = oldStateInline;
-                    state._list = oldStateList;
-
-                    return result;
-                });
-
-                return {
-                    items: itemContent,
-                    ordered: ordered,
-                    start: start,
-                };
-            },
-            react (node, output, state) {
-                const Tag = node.ordered ? 'ol' : 'ul';
-
-                return (
-                    <Tag key={state.key} start={node.start}>
-                        {node.items.map(function generateListItem (item, i) {
-                            return (
-                                <li key={i}>
-                                    {output(item, state)}
-                                </li>
-                            );
-                        })}
-                    </Tag>
-                );
-            },
-        },
-
-        newlineCoalescer: {
-            match: blockRegex(CONSECUTIVE_NEWLINE_R),
-            order: PARSE_PRIORITY_LOW,
-            parse: captureNothing,
-            react (/*node, output, state*/) { return '\n'; },
-        },
-
-        paragraph: {
-            match: blockRegex(PARAGRAPH_R),
-            order: PARSE_PRIORITY_LOW,
-            parse: parseCaptureInline,
-            react (node, output, state) {
-                return (
-                    <p key={state.key}>
-                        {output(node.content, state)}
-                    </p>
-                );
-            },
-        },
-
-        ref: {
-            match: inlineRegex(REFERENCE_IMAGE_OR_LINK),
-            order: PARSE_PRIORITY_MAX,
-            parse (capture/*, parse*/) {
-                refs[capture[1]] = {
-                    target: capture[2],
-                    title: capture[4],
-                };
-
-                return {};
-            },
-            react: renderNothing,
-        },
-
-        refImage: {
-            match: inlineRegex(REFERENCE_IMAGE_R),
-            order: PARSE_PRIORITY_MAX,
-            parse (capture) {
-                return {
-                    alt: capture[1] || undefined,
-                    ref: capture[2],
-                };
-            },
-            react (node, output, state) {
-                return (
-                    <img
-                        key={state.key}
-                        alt={node.alt}
-                        src={sanitizeUrl(refs[node.ref].target)}
-                        title={refs[node.ref].title}
-                    />
-                );
-            },
-        },
-
-        refLink: {
-            match: inlineRegex(REFERENCE_LINK_R),
-            order: PARSE_PRIORITY_MAX,
-            parse (capture, parse, state) {
-                return {
-                    content: parse(capture[1], state),
-                    ref: capture[2],
-                };
-            },
-            react (node, output, state) {
-                return (
-                    <a
-                        key={state.key}
-                        href={sanitizeUrl(refs[node.ref].target)}
-                        title={refs[node.ref].title}
-                    >
-                        {output(node.content, state)}
-                    </a>
-                );
-            },
-        },
-
-        table: {
-            match: blockRegex(NP_TABLE_R),
-            order: PARSE_PRIORITY_HIGH,
-            parse: parseTable,
-            react (node, output, state) {
-                return (
-                    <table key={state.key}>
-                        <thead>
-                            <tr>
-                                {node.header.map(function generateHeaderCell (content, i) {
-                                    return (
-                                        <th
-                                            key={i}
-                                            style={getTableStyle(node, i)}
-                                            scope="col"
-                                        >
-                                            {output(content, state)}
-                                        </th>
-                                    );
-                                })}
-                            </tr>
-                        </thead>
-
-                        <tbody>
-                            {node.cells.map(function generateTableRow (row, i) {
-                                return (
-                                    <tr key={i}>
-                                        {row.map(function generateTableCell (content, c) {
-                                            return (
-                                                <td key={c} style={getTableStyle(node, c)}>
-                                                    {output(content, state)}
-                                                </td>
-                                            );
-                                        })}
-                                    </tr>
-                                );
-                            })}
-                        </tbody>
-                    </table>
-                );
-            },
-        },
-
-        text: {
-            // Here we look for anything followed by non-symbols,
-            // double newlines, or double-space-newlines
-            // We break on any symbol characters so that this grammar
-            // is easy to extend without needing to modify this regex
-            match: inlineRegex(TEXT_PLAIN_R),
-            order: PARSE_PRIORITY_MIN,
-            parse (capture/*, parse, state*/) {
-                return {
-                    content: capture[0],
-                };
-            },
-            react (node/*, output, state*/) {
-                return node.content;
-            },
-        },
-
-        textBolded: {
-            match: inlineRegex(TEXT_BOLD_R),
-            order: PARSE_PRIORITY_MED,
-            parse: parseCaptureInline,
-            react (node, output, state) {
-                return (
-                    <strong key={state.key}>
-                        {output(node.content, state)}
-                    </strong>
-                );
-            },
-        },
-
-        textEmphasized: {
-            match: inlineRegex(TEXT_EMPHASIZED_R),
-            order: PARSE_PRIORITY_LOW,
-            parse (capture, parse, state) {
-                return {
-                    content: parse(capture[2] || capture[1], state),
-                };
-            },
-            react (node, output, state) {
-                return (
-                    <em key={state.key}>
-                        {output(node.content, state)}
-                    </em>
-                );
-            },
-        },
-
-        textEscaped: {
-            // We don't allow escaping numbers, letters, or spaces here so that
-            // backslashes used in plain text still get rendered. But allowing
-            // escaping anything else provides a very flexible escape mechanism,
-            // regardless of how this grammar is extended.
-            match: inlineRegex(TEXT_ESCAPED_R),
-            order: PARSE_PRIORITY_HIGH,
-            parse (capture/*, parse, state*/) {
-                return {
-                    content: capture[1],
-                    type: 'text',
-                };
-            },
-        },
-
-        textStrikethroughed: {
-            match: inlineRegex(TEXT_STRIKETHROUGHED_R),
-            order: PARSE_PRIORITY_LOW,
-            parse: parseCaptureInline,
-            react (node, output, state) {
-                return (
-                    <del key={state.key}>
-                        {output(node.content, state)}
-                    </del>
-                );
-            },
-        },
-    };
-
-    // Object.keys(rules).forEach(key => {
-    //     let parse = rules[key].parse;
-
-    //     rules[key].parse = (...args) => {
-    //         console.log(key, args[0]);
-    //         return parse(...args);
-    //     };
-    // });
-
-    const parser = parserFor(rules);
-    const emitter = reactFor(ruleOutput(rules));
-
-    const jsx = compile(markdown);
-
-    if (footnotes.length) {
-        jsx.props.children.push(
-            <footer>
-                {footnotes.map(function createFootnote (def) {
-                    return (
-                        <div id={def.identifier} key={def.identifier}>
-                            {def.identifier}{emitter(parser(def.footnote, { inline: true }))}
-                        </div>
-                    );
-                })}
-            </footer>
+    footnoteReference: {
+      match: inlineRegex(FOOTNOTE_REFERENCE_R),
+      order: PARSE_PRIORITY_HIGH,
+      parse(capture /*, parse*/) {
+        return {
+          content: capture[1],
+          target: `#${capture[1]}`
+        };
+      },
+      react(node, output, state) {
+        return (
+          <a key={state.key} href={sanitizeUrl(node.target)}>
+            <sup key={state.key}>{node.content}</sup>
+          </a>
         );
-    }
+      }
+    },
 
-    return jsx;
+    gfmTask: {
+      match: inlineRegex(GFM_TASK_R),
+      order: PARSE_PRIORITY_HIGH,
+      parse(capture /*, parse, state*/) {
+        return {
+          completed: capture[1].toLowerCase() === 'x'
+        };
+      },
+      react(node, output, state) {
+        return (
+          <input
+            checked={node.completed}
+            key={state.key}
+            readOnly
+            type="checkbox"
+          />
+        );
+      }
+    },
+
+    heading: {
+      match: blockRegex(HEADING_R),
+      order: PARSE_PRIORITY_HIGH,
+      parse(capture, parse, state) {
+        return {
+          content: parseInline(parse, capture[2], state),
+          level: capture[1].length
+        };
+      },
+      react(node, output, state) {
+        const Tag = `h${node.level}`;
+        return <Tag key={state.key}>{output(node.content, state)}</Tag>;
+      }
+    },
+
+    headingSetext: {
+      match: blockRegex(HEADING_SETEXT_R),
+      order: PARSE_PRIORITY_MAX,
+      parse(capture, parse, state) {
+        return {
+          content: parseInline(parse, capture[1], state),
+          level: capture[2] === '=' ? 1 : 2,
+          type: 'heading'
+        };
+      }
+    },
+
+    htmlBlock: {
+      /**
+       * find the first matching end tag and process the interior
+       */
+      match: anyScopeRegex(HTML_BLOCK_ELEMENT_R),
+      order: PARSE_PRIORITY_HIGH,
+      parse(capture, parse, state) {
+        const parseFunc = capture[3].match(HTML_BLOCK_ELEMENT_R)
+          ? parseBlock
+          : parseInline;
+
+        return {
+          attrs: attrStringToMap(capture[2]),
+          /**
+           * if another html block is detected within, parse as block,
+           * otherwise parse as inline to pick up any further markdown
+           */
+          content: parseFunc(parse, capture[3].trim(), state),
+
+          tag: capture[1]
+        };
+      },
+      react(node, output, state) {
+        return (
+          <node.tag key={state.key} {...node.attrs}>
+            {output(node.content, state)}
+          </node.tag>
+        );
+      }
+    },
+
+    htmlComment: {
+      match: anyScopeRegex(HTML_COMMENT_R),
+      order: PARSE_PRIORITY_HIGH,
+      parse() {
+        return {};
+      },
+      react: renderNothing
+    },
+
+    htmlSelfClosing: {
+      /**
+       * find the first matching end tag and process the interior
+       */
+      match: anyScopeRegex(HTML_SELF_CLOSING_ELEMENT_R),
+      order: PARSE_PRIORITY_HIGH,
+      parse(capture /*, parse, state*/) {
+        return {
+          attrs: attrStringToMap(capture[2]),
+          tag: capture[1]
+        };
+      },
+      react(node, output, state) {
+        return <node.tag {...node.attrs} key={state.key} />;
+      }
+    },
+
+    image: {
+      match: inlineRegex(IMAGE_R),
+      order: PARSE_PRIORITY_HIGH,
+      parse(capture /*, parse, state*/) {
+        return {
+          alt: capture[1],
+          target: unescapeUrl(capture[2]),
+          title: capture[3]
+        };
+      },
+      react(node, output, state) {
+        return (
+          <img
+            key={state.key}
+            alt={node.alt || undefined}
+            title={node.title || undefined}
+            src={sanitizeUrl(node.target)}
+          />
+        );
+      }
+    },
+
+    link: {
+      match: inlineRegex(LINK_R),
+      order: PARSE_PRIORITY_LOW,
+      parse(capture, parse, state) {
+        return {
+          content: parse(capture[1], state),
+          target: unescapeUrl(capture[2]),
+          title: capture[3]
+        };
+      },
+      react(node, output, state) {
+        return (
+          <a key={state.key} href={sanitizeUrl(node.target)} title={node.title}>
+            {output(node.content, state)}
+          </a>
+        );
+      }
+    },
+
+    // https://daringfireball.net/projects/markdown/syntax#autolink
+    linkAngleBraceStyleDetector: {
+      match: inlineRegex(LINK_AUTOLINK_R),
+      order: PARSE_PRIORITY_MAX,
+      parse(capture /*, parse, state*/) {
+        return {
+          content: [
+            {
+              content: capture[1],
+              type: 'text'
+            }
+          ],
+          target: capture[1],
+          type: 'link'
+        };
+      }
+    },
+
+    linkBareUrlDetector: {
+      match: inlineRegex(LINK_AUTOLINK_BARE_URL_R),
+      order: PARSE_PRIORITY_MAX,
+      parse(capture /*, parse, state*/) {
+        return {
+          content: [
+            {
+              content: capture[1],
+              type: 'text'
+            }
+          ],
+          target: capture[1],
+          title: undefined,
+          type: 'link'
+        };
+      }
+    },
+
+    linkMailtoDetector: {
+      match: inlineRegex(LINK_AUTOLINK_MAILTO_R),
+      order: PARSE_PRIORITY_MAX,
+      parse(capture /*, parse, state*/) {
+        let address = capture[1];
+        let target = capture[1];
+
+        // Check for a `mailto:` already existing in the link:
+        if (!AUTOLINK_MAILTO_CHECK_R.test(target)) {
+          target = 'mailto:' + target;
+        }
+
+        return {
+          content: [
+            {
+              content: address.replace('mailto:', ''),
+              type: 'text'
+            }
+          ],
+          target: target,
+          type: 'link'
+        };
+      }
+    },
+
+    list: {
+      match(source, state, prevCapture) {
+        // We only want to break into a list if we are at the start of a
+        // line. This is to avoid parsing "hi * there" with "* there"
+        // becoming a part of a list.
+        // You might wonder, "but that's inline, so of course it wouldn't
+        // start a list?". You would be correct! Except that some of our
+        // lists can be inline, because they might be inside another list,
+        // in which case we can parse with inline scope, but need to allow
+        // nested lists inside this inline scope.
+        const isStartOfLine = LIST_LOOKBEHIND_R.test(prevCapture);
+        const isListBlock = state._list || !state.inline;
+
+        if (isStartOfLine && isListBlock) {
+          return LIST_R.exec(source);
+        } else {
+          return null;
+        }
+      },
+      order: PARSE_PRIORITY_HIGH,
+      parse(capture, parse, state) {
+        const bullet = capture[2];
+        const ordered = bullet.length > 1;
+        const start = ordered ? +bullet : undefined;
+        const items = capture[0]
+          // recognize the end of a paragraph block inside a list item:
+          // two or more newlines at end end of the item
+          .replace(BLOCK_END_R, '\n')
+          .match(LIST_ITEM_R);
+
+        let lastItemWasAParagraph = false;
+        const itemContent = items.map(function(item, i) {
+          // We need to see how far indented this item is:
+          const space = LIST_ITEM_PREFIX_R.exec(item)[0].length;
+
+          // And then we construct a regex to "unindent" the subsequent
+          // lines of the items by that amount:
+          const spaceRegex = new RegExp('^ {1,' + space + '}', 'gm');
+
+          // Before processing the item, we need a couple things
+          const content = item
+            // remove indents on trailing lines:
+            .replace(spaceRegex, '')
+            // remove the bullet:
+            .replace(LIST_ITEM_PREFIX_R, '');
+
+          // Handling "loose" lists, like:
+          //
+          //  * this is wrapped in a paragraph
+          //
+          //  * as is this
+          //
+          //  * as is this
+          const isLastItem = i === items.length - 1;
+          const containsBlocks = content.indexOf('\n\n') !== -1;
+
+          // Any element in a list is a block if it contains multiple
+          // newlines. The last element in the list can also be a block
+          // if the previous item in the list was a block (this is
+          // because non-last items in the list can end with \n\n, but
+          // the last item can't, so we just "inherit" this property
+          // from our previous element).
+          const thisItemIsAParagraph =
+            containsBlocks || (isLastItem && lastItemWasAParagraph);
+          lastItemWasAParagraph = thisItemIsAParagraph;
+
+          // backup our state for restoration afterwards. We're going to
+          // want to set state._list to true, and state.inline depending
+          // on our list's looseness.
+          const oldStateInline = state.inline;
+          const oldStateList = state._list;
+          state._list = true;
+
+          // Parse inline if we're in a tight list, or block if we're in
+          // a loose list.
+          let adjustedContent;
+          if (thisItemIsAParagraph) {
+            state.inline = false;
+            adjustedContent = content.replace(LIST_ITEM_END_R, '\n\n');
+          } else {
+            state.inline = true;
+            adjustedContent = content.replace(LIST_ITEM_END_R, '');
+          }
+
+          const result = parse(adjustedContent, state);
+
+          // Restore our state before returning
+          state.inline = oldStateInline;
+          state._list = oldStateList;
+
+          return result;
+        });
+
+        return {
+          items: itemContent,
+          ordered: ordered,
+          start: start
+        };
+      },
+      react(node, output, state) {
+        const Tag = node.ordered ? 'ol' : 'ul';
+
+        return (
+          <Tag key={state.key} start={node.start}>
+            {node.items.map(function generateListItem(item, i) {
+              return <li key={i}>{output(item, state)}</li>;
+            })}
+          </Tag>
+        );
+      }
+    },
+
+    newlineCoalescer: {
+      match: blockRegex(CONSECUTIVE_NEWLINE_R),
+      order: PARSE_PRIORITY_LOW,
+      parse: captureNothing,
+      react(/*node, output, state*/) {
+        return '\n';
+      }
+    },
+
+    paragraph: {
+      match: blockRegex(PARAGRAPH_R),
+      order: PARSE_PRIORITY_LOW,
+      parse: parseCaptureInline,
+      react(node, output, state) {
+        return <p key={state.key}>{output(node.content, state)}</p>;
+      }
+    },
+
+    ref: {
+      match: inlineRegex(REFERENCE_IMAGE_OR_LINK),
+      order: PARSE_PRIORITY_MAX,
+      parse(capture /*, parse*/) {
+        refs[capture[1]] = {
+          target: capture[2],
+          title: capture[4]
+        };
+
+        return {};
+      },
+      react: renderNothing
+    },
+
+    refImage: {
+      match: inlineRegex(REFERENCE_IMAGE_R),
+      order: PARSE_PRIORITY_MAX,
+      parse(capture) {
+        return {
+          alt: capture[1] || undefined,
+          ref: capture[2]
+        };
+      },
+      react(node, output, state) {
+        return (
+          <img
+            key={state.key}
+            alt={node.alt}
+            src={sanitizeUrl(refs[node.ref].target)}
+            title={refs[node.ref].title}
+          />
+        );
+      }
+    },
+
+    refLink: {
+      match: inlineRegex(REFERENCE_LINK_R),
+      order: PARSE_PRIORITY_MAX,
+      parse(capture, parse, state) {
+        return {
+          content: parse(capture[1], state),
+          ref: capture[2]
+        };
+      },
+      react(node, output, state) {
+        return (
+          <a
+            key={state.key}
+            href={sanitizeUrl(refs[node.ref].target)}
+            title={refs[node.ref].title}>
+            {output(node.content, state)}
+          </a>
+        );
+      }
+    },
+
+    table: {
+      match: blockRegex(NP_TABLE_R),
+      order: PARSE_PRIORITY_HIGH,
+      parse: parseTable,
+      react(node, output, state) {
+        return (
+          <table key={state.key}>
+            <thead>
+              <tr>
+                {node.header.map(function generateHeaderCell(content, i) {
+                  return (
+                    <th key={i} style={getTableStyle(node, i)} scope="col">
+                      {output(content, state)}
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+
+            <tbody>
+              {node.cells.map(function generateTableRow(row, i) {
+                return (
+                  <tr key={i}>
+                    {row.map(function generateTableCell(content, c) {
+                      return (
+                        <td key={c} style={getTableStyle(node, c)}>
+                          {output(content, state)}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        );
+      }
+    },
+
+    text: {
+      // Here we look for anything followed by non-symbols,
+      // double newlines, or double-space-newlines
+      // We break on any symbol characters so that this grammar
+      // is easy to extend without needing to modify this regex
+      match: inlineRegex(TEXT_PLAIN_R),
+      order: PARSE_PRIORITY_MIN,
+      parse(capture /*, parse, state*/) {
+        return {
+          content: capture[0]
+        };
+      },
+      react(node /*, output, state*/) {
+        return node.content;
+      }
+    },
+
+    textBolded: {
+      match: inlineRegex(TEXT_BOLD_R),
+      order: PARSE_PRIORITY_MED,
+      parse: parseCaptureInline,
+      react(node, output, state) {
+        return <strong key={state.key}>{output(node.content, state)}</strong>;
+      }
+    },
+
+    textEmphasized: {
+      match: inlineRegex(TEXT_EMPHASIZED_R),
+      order: PARSE_PRIORITY_LOW,
+      parse(capture, parse, state) {
+        return {
+          content: parse(capture[2] || capture[1], state)
+        };
+      },
+      react(node, output, state) {
+        return <em key={state.key}>{output(node.content, state)}</em>;
+      }
+    },
+
+    textEscaped: {
+      // We don't allow escaping numbers, letters, or spaces here so that
+      // backslashes used in plain text still get rendered. But allowing
+      // escaping anything else provides a very flexible escape mechanism,
+      // regardless of how this grammar is extended.
+      match: inlineRegex(TEXT_ESCAPED_R),
+      order: PARSE_PRIORITY_HIGH,
+      parse(capture /*, parse, state*/) {
+        return {
+          content: capture[1],
+          type: 'text'
+        };
+      }
+    },
+
+    textStrikethroughed: {
+      match: inlineRegex(TEXT_STRIKETHROUGHED_R),
+      order: PARSE_PRIORITY_LOW,
+      parse: parseCaptureInline,
+      react(node, output, state) {
+        return <del key={state.key}>{output(node.content, state)}</del>;
+      }
+    }
+  };
+
+  // Object.keys(rules).forEach(key => {
+  //     let parse = rules[key].parse;
+
+  //     rules[key].parse = (...args) => {
+  //         console.log(key, args[0]);
+  //         return parse(...args);
+  //     };
+  // });
+
+  const parser = parserFor(rules);
+  const emitter = reactFor(ruleOutput(rules));
+
+  const jsx = compile(markdown);
+
+  if (footnotes.length) {
+    jsx.props.children.push(
+      <footer>
+        {footnotes.map(function createFootnote(def) {
+          return (
+            <div id={def.identifier} key={def.identifier}>
+              {def.identifier}
+              {emitter(parser(def.footnote, { inline: true }))}
+            </div>
+          );
+        })}
+      </footer>
+    );
+  }
+
+  return jsx;
 }
 
 /**
@@ -1403,15 +1396,15 @@ export function compiler (markdown, options) {
  * @return {ReactElement} the compiled JSX
  */
 
-export default function Markdown (props) {
-    return compiler(props.children, props.options);
+export default function Markdown(props) {
+  return compiler(props.children, props.options);
 }
 
 if (process.env.NODE_ENV !== 'production') {
-    const PropTypes = require('prop-types');
+  const PropTypes = require('prop-types');
 
-    Markdown.propTypes = {
-        children: PropTypes.string.isRequired,
-        options: PropTypes.object,
-    };
+  Markdown.propTypes = {
+    children: PropTypes.string.isRequired,
+    options: PropTypes.object
+  };
 }

--- a/index.js
+++ b/index.js
@@ -1358,7 +1358,7 @@ export function compiler(markdown, options) {
   Object.keys(options.react).forEach(key => {
     const original = rules[key];
 
-    if (!original) {
+    if (!original || !original.react) {
       return;
     }
 

--- a/index.spec.js
+++ b/index.spec.js
@@ -1,511 +1,482 @@
-import Markdown, {compiler} from './index';
+import Markdown, { compiler } from './index';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import fs from 'fs';
 
 describe('markdown-to-jsx', () => {
-    const root = document.body.appendChild(document.createElement('div'));
-    function render (jsx) { return ReactDOM.render(jsx, root); }
+  const root = document.body.appendChild(document.createElement('div'));
+  function render(jsx) {
+    return ReactDOM.render(jsx, root);
+  }
 
-    afterEach(() => ReactDOM.unmountComponentAtNode(root));
+  afterEach(() => ReactDOM.unmountComponentAtNode(root));
 
-    describe('compiler', () => {
-        it('should throw if not passed a string (first arg)', () => {
-            expect(() => compiler('')).not.toThrow();
+  describe('compiler', () => {
+    it('should throw if not passed a string (first arg)', () => {
+      expect(() => compiler('')).not.toThrow();
 
-            expect(() => compiler()).toThrow();
-            expect(() => compiler(1)).toThrow();
-            expect(() => compiler(() => {})).toThrow();
-            expect(() => compiler({})).toThrow();
-            expect(() => compiler([])).toThrow();
-            expect(() => compiler(null)).toThrow();
-            expect(() => compiler(true)).toThrow();
-        });
+      expect(() => compiler()).toThrow();
+      expect(() => compiler(1)).toThrow();
+      expect(() => compiler(() => {})).toThrow();
+      expect(() => compiler({})).toThrow();
+      expect(() => compiler([])).toThrow();
+      expect(() => compiler(null)).toThrow();
+      expect(() => compiler(true)).toThrow();
+    });
 
-        it('should handle a basic string', () => {
-            render(compiler('Hello.'));
+    it('should handle a basic string', () => {
+      render(compiler('Hello.'));
 
-            expect(root.textContent).toBe('Hello.');
-        });
+      expect(root.textContent).toBe('Hello.');
+    });
 
-        it('wraps multiple block element returns in a div to avoid invalid nesting errors', () => {
-            render(compiler('# Boop\n\n## Blep'));
+    it('wraps multiple block element returns in a div to avoid invalid nesting errors', () => {
+      render(compiler('# Boop\n\n## Blep'));
 
-            expect(root.innerHTML).toMatchSnapshot();
-        });
+      expect(root.innerHTML).toMatchSnapshot();
+    });
 
-        it('wraps solely inline elements in a span, rather than a div', () => {
-            render(compiler('Hello. _Beautiful_ day isn\'t it?'));
+    it('wraps solely inline elements in a span, rather than a div', () => {
+      render(compiler("Hello. _Beautiful_ day isn't it?"));
 
-            expect(root.innerHTML).toMatchSnapshot();
-        });
+      expect(root.innerHTML).toMatchSnapshot();
+    });
 
-        it('handles a hollistic example', () => {
-            const md = fs.readFileSync(__dirname + '/fixture.md', 'utf8');
-            render(compiler(md));
+    it('handles a hollistic example', () => {
+      const md = fs.readFileSync(__dirname + '/fixture.md', 'utf8');
+      render(compiler(md));
 
-            expect(root.innerHTML).toMatchSnapshot();
-        });
+      expect(root.innerHTML).toMatchSnapshot();
+    });
 
-        describe('inline textual elements', () => {
-            it('should handle emphasized text', () => {
-                render(compiler('*Hello.*'));
+    describe('inline textual elements', () => {
+      it('should handle emphasized text', () => {
+        render(compiler('*Hello.*'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle double-emphasized text', () => {
-                render(compiler('**Hello.**'));
+      it('should handle double-emphasized text', () => {
+        render(compiler('**Hello.**'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle triple-emphasized text', () => {
-                render(compiler('***Hello.***'));
+      it('should handle triple-emphasized text', () => {
+        render(compiler('***Hello.***'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle the alternate form of bold/italic', () => {
-                render(compiler('___Hello.___'));
+      it('should handle the alternate form of bold/italic', () => {
+        render(compiler('___Hello.___'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle deleted text', () => {
-                render(compiler('~~Hello.~~'));
+      it('should handle deleted text', () => {
+        render(compiler('~~Hello.~~'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle escaped text', () => {
-                render(compiler('Hello.\\_\\_foo\\_\\_'));
+      it('should handle escaped text', () => {
+        render(compiler('Hello.\\_\\_foo\\_\\_'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
 
-        describe('misc block level elements', () => {
-            it('should handle blockquotes', () => {
-                render(compiler('> Something important, perhaps?'));
+    describe('misc block level elements', () => {
+      it('should handle blockquotes', () => {
+        render(compiler('> Something important, perhaps?'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
 
-        describe('headings', () => {
-            it('should handle level 1 properly', () => {
-                render(compiler('# Hello World'));
+    describe('headings', () => {
+      it('should handle level 1 properly', () => {
+        render(compiler('# Hello World'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle level 2 properly', () => {
-                render(compiler('## Hello World'));
+      it('should handle level 2 properly', () => {
+        render(compiler('## Hello World'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle level 3 properly', () => {
-                render(compiler('### Hello World'));
+      it('should handle level 3 properly', () => {
+        render(compiler('### Hello World'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle level 4 properly', () => {
-                render(compiler('#### Hello World'));
+      it('should handle level 4 properly', () => {
+        render(compiler('#### Hello World'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle level 5 properly', () => {
-                render(compiler('##### Hello World'));
+      it('should handle level 5 properly', () => {
+        render(compiler('##### Hello World'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle level 6 properly', () => {
-                render(compiler('###### Hello World'));
+      it('should handle level 6 properly', () => {
+        render(compiler('###### Hello World'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle setext level 1 style', () => {
-                render(compiler('Hello World\n===========\n\nsomething'));
+      it('should handle setext level 1 style', () => {
+        render(compiler('Hello World\n===========\n\nsomething'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle setext level 2 style', () => {
-                render(compiler('Hello World\n-----------\n\nsomething'));
+      it('should handle setext level 2 style', () => {
+        render(compiler('Hello World\n-----------\n\nsomething'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle consecutive headings without a padding newline', () => {
-                render(compiler('# Hello World\n## And again'));
+      it('should handle consecutive headings without a padding newline', () => {
+        render(compiler('# Hello World\n## And again'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
 
-        describe('images', () => {
-            it('should handle a basic image', () => {
-                render(compiler('![](/xyz.png)'));
+    describe('images', () => {
+      it('should handle a basic image', () => {
+        render(compiler('![](/xyz.png)'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle an image with alt text', () => {
-                render(compiler('![test](/xyz.png)'));
+      it('should handle an image with alt text', () => {
+        render(compiler('![test](/xyz.png)'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle an image with title', () => {
-                render(compiler('![test](/xyz.png "foo")'));
+      it('should handle an image with title', () => {
+        render(compiler('![test](/xyz.png "foo")'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle an image reference', () => {
-                render(compiler([
-                    '![][1]',
-                    '[1]: /xyz.png',
-                ].join('\n')));
+      it('should handle an image reference', () => {
+        render(compiler(['![][1]', '[1]: /xyz.png'].join('\n')));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle an image reference with alt text', () => {
-                render(compiler([
-                    '![test][1]',
-                    '[1]: /xyz.png',
-                ].join('\n')));
+      it('should handle an image reference with alt text', () => {
+        render(compiler(['![test][1]', '[1]: /xyz.png'].join('\n')));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle an image reference with title', () => {
-                render(compiler([
-                    '![test][1]',
-                    '[1]: /xyz.png "foo"',
-                ].join('\n')));
+      it('should handle an image reference with title', () => {
+        render(compiler(['![test][1]', '[1]: /xyz.png "foo"'].join('\n')));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
 
-        describe('links', () => {
-            it('should handle a basic link', () => {
-                render(compiler('[foo](/xyz.png)'));
+    describe('links', () => {
+      it('should handle a basic link', () => {
+        render(compiler('[foo](/xyz.png)'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle a link with title', () => {
-                render(compiler('[foo](/xyz.png "bar")'));
+      it('should handle a link with title', () => {
+        render(compiler('[foo](/xyz.png "bar")'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle a link reference', () => {
-                render(compiler([
-                    '[foo][1]',
-                    '[1]: /xyz.png',
-                ].join('\n')));
+      it('should handle a link reference', () => {
+        render(compiler(['[foo][1]', '[1]: /xyz.png'].join('\n')));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle a link reference with a space', () => {
-                render(compiler([
-                    '[foo] [1]',
-                    '[1]: /xyz.png',
-                ].join('\n')));
+      it('should handle a link reference with a space', () => {
+        render(compiler(['[foo] [1]', '[1]: /xyz.png'].join('\n')));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle a link reference with title', () => {
-                render(compiler([
-                    '[foo][1]',
-                    '[1]: /xyz.png "bar"',
-                ].join('\n')));
+      it('should handle a link reference with title', () => {
+        render(compiler(['[foo][1]', '[1]: /xyz.png "bar"'].join('\n')));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle autolink style', () => {
-                render(compiler('<https://google.com>'));
+      it('should handle autolink style', () => {
+        render(compiler('<https://google.com>'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle a mailto autolink', () => {
-                render(compiler('<mailto:probablyup@gmail.com>'));
+      it('should handle a mailto autolink', () => {
+        render(compiler('<mailto:probablyup@gmail.com>'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should an email autolink and add a mailto: prefix', () => {
-                render(compiler('<probablyup@gmail.com>'));
+      it('should an email autolink and add a mailto: prefix', () => {
+        render(compiler('<probablyup@gmail.com>'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should automatically link found URLs', () => {
-                render(compiler('https://google.com'));
+      it('should automatically link found URLs', () => {
+        render(compiler('https://google.com'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should sanitize links containing JS expressions', () => {
-                render(compiler('[foo](javascript:doSomethingBad)'));
+      it('should sanitize links containing JS expressions', () => {
+        render(compiler('[foo](javascript:doSomethingBad)'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should sanitize links containing invalid characters', () => {
-                render(compiler('[foo](https://google.com/%AF)'));
+      it('should sanitize links containing invalid characters', () => {
+        render(compiler('[foo](https://google.com/%AF)'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
 
-        describe('lists', () => {
-            it('should handle a tight list', () => {
-                render(compiler([
-                    '- xyz',
-                    '- abc',
-                    '- foo',
-                ].join('\n')));
+    describe('lists', () => {
+      it('should handle a tight list', () => {
+        render(compiler(['- xyz', '- abc', '- foo'].join('\n')));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle a loose list', () => {
-                render(compiler([
-                    '- xyz',
-                    '',
-                    '- abc',
-                    '',
-                    '- foo',
-                ].join('\n')));
+      it('should handle a loose list', () => {
+        render(compiler(['- xyz', '', '- abc', '', '- foo'].join('\n')));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle an ordered list', () => {
-                render(compiler([
-                    '1. xyz',
-                    '1. abc',
-                    '1. foo',
-                ].join('\n')));
+      it('should handle an ordered list', () => {
+        render(compiler(['1. xyz', '1. abc', '1. foo'].join('\n')));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle an ordered list with a specific start index', () => {
-                render(compiler([
-                    '2. xyz',
-                    '3. abc',
-                    '4. foo',
-                ].join('\n')));
+      it('should handle an ordered list with a specific start index', () => {
+        render(compiler(['2. xyz', '3. abc', '4. foo'].join('\n')));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle a nested list', () => {
-                render(compiler([
-                    '- xyz',
-                    '  - abc',
-                    '- foo',
-                ].join('\n')));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-
-            it('should handle a mixed nested list', () => {
-                render(compiler([
-                    '- xyz',
-                    '  1. abc',
-                    '    - def',
-                    '- foo',
-                ].join('\n')));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-
-            it('should not add an extra wrapper around a list', () => {
-                render(compiler([
-                    '',
-                    '- xyz',
-                    '  1. abc',
-                    '    - def',
-                    '- foo',
-                    '',
-                ].join('\n')));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
-
-        describe('GFM task lists', () => {
-            it('should handle unchecked items', () => {
-                render(compiler('- [ ] foo'));
-
-                const checkbox = root.querySelector('ul li input');
+      it('should handle a nested list', () => {
+        render(compiler(['- xyz', '  - abc', '- foo'].join('\n')));
 
-                expect(root.innerHTML).toMatchSnapshot();
-                expect(checkbox.checked).toBe(false);
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('should handle checked items', () => {
-                render(compiler('- [x] foo'));
+      it('should handle a mixed nested list', () => {
+        render(
+          compiler(['- xyz', '  1. abc', '    - def', '- foo'].join('\n'))
+        );
 
-                const checkbox = root.querySelector('ul li input');
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-                expect(checkbox.checked).toBe(true);
-            });
+      it('should not add an extra wrapper around a list', () => {
+        render(
+          compiler(
+            ['', '- xyz', '  1. abc', '    - def', '- foo', ''].join('\n')
+          )
+        );
 
-            it('should mark the checkboxes as readonly', () => {
-                render(compiler('- [x] foo'));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
 
-                const checkbox = root.querySelector('ul li input');
+    describe('GFM task lists', () => {
+      it('should handle unchecked items', () => {
+        render(compiler('- [ ] foo'));
 
-                expect(checkbox).not.toBe(null);
-                expect(checkbox.readOnly).toBe(true);
-            });
-        });
+        const checkbox = root.querySelector('ul li input');
 
-        describe('GFM tables', () => {
-            it('should handle a basic table', () => {
-                render(compiler([
-                    'foo|bar',
-                    '---|---',
-                    '1  |2',
-                ].join('\n')));
+        expect(root.innerHTML).toMatchSnapshot();
+        expect(checkbox.checked).toBe(false);
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+      it('should handle checked items', () => {
+        render(compiler('- [x] foo'));
 
-            it('should handle a table with aligned columns', () => {
-                render(compiler([
-                    'foo|bar|baz',
-                    '--:|:---:|:--',
-                    '1|2|3',
-                ].join('\n')));
+        const checkbox = root.querySelector('ul li input');
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+        expect(checkbox.checked).toBe(true);
+      });
 
-            it('should handle the other syntax for tables', () => {
-                render(compiler([
-                    '| Foo | Bar |',
-                    '| --- | --- |',
-                    '| 1   | 2   |',
-                    '| 3   | 4   |',
-                ].join('\n')));
+      it('should mark the checkboxes as readonly', () => {
+        render(compiler('- [x] foo'));
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        const checkbox = root.querySelector('ul li input');
 
-            it('should handle the other syntax for tables with alignment', () => {
-                render(compiler([
-                    '| Foo | Bar | Baz |',
-                    '| --: | :-: | :-- |',
-                    '| 1   | 2   | 3   |',
-                    '| 4   | 5   | 6   |',
-                ].join('\n')));
+        expect(checkbox).not.toBe(null);
+        expect(checkbox.readOnly).toBe(true);
+      });
+    });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+    describe('GFM tables', () => {
+      it('should handle a basic table', () => {
+        render(compiler(['foo|bar', '---|---', '1  |2'].join('\n')));
 
-            it('should handle other content after a table', () => {
-                render(compiler([
-                    '| Foo | Bar | Baz |',
-                    '| --: | :-: | :-- |',
-                    '| 1   | 2   | 3   |',
-                    '| 4   | 5   | 6   |',
-                    '',
-                    'Foo',
-                ].join('\n')));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
+      it('should handle a table with aligned columns', () => {
+        render(compiler(['foo|bar|baz', '--:|:---:|:--', '1|2|3'].join('\n')));
 
-        describe('arbitrary HTML', () => {
-            it('preserves the HTML given', () => {
-                render(compiler('<dd>Hello</dd>'));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+      it('should handle the other syntax for tables', () => {
+        render(
+          compiler(
+            [
+              '| Foo | Bar |',
+              '| --- | --- |',
+              '| 1   | 2   |',
+              '| 3   | 4   |'
+            ].join('\n')
+          )
+        );
 
-            it('processes markdown within inline HTML', () => {
-                render(compiler('<time>**Hello**</time>'));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+      it('should handle the other syntax for tables with alignment', () => {
+        render(
+          compiler(
+            [
+              '| Foo | Bar | Baz |',
+              '| --: | :-: | :-- |',
+              '| 1   | 2   | 3   |',
+              '| 4   | 5   | 6   |'
+            ].join('\n')
+          )
+        );
 
-            it('processes markdown within nested inline HTML', () => {
-                render(compiler('<time><span>**Hello**</span></time>'));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+      it('should handle other content after a table', () => {
+        render(
+          compiler(
+            [
+              '| Foo | Bar | Baz |',
+              '| --: | :-: | :-- |',
+              '| 1   | 2   | 3   |',
+              '| 4   | 5   | 6   |',
+              '',
+              'Foo'
+            ].join('\n')
+          )
+        );
 
-            it('processes markdown within nested inline HTML where childen appear more than once', () => {
-                render(compiler('<dl><dt>foo</dt><dd>bar</dd><dt>baz</dt><dd>qux</dd></dl>'));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+    describe('arbitrary HTML', () => {
+      it('preserves the HTML given', () => {
+        render(compiler('<dd>Hello</dd>'));
 
-            it('processes attributes within inline HTML', () => {
-                render(compiler('<time data-foo="bar">Hello</time>'));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+      it('processes markdown within inline HTML', () => {
+        render(compiler('<time>**Hello**</time>'));
 
-            it('processes attributes that need JSX massaging within inline HTML', () => {
-                render(compiler('<span tabindex="0">Hello</span>'));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+      it('processes markdown within nested inline HTML', () => {
+        render(compiler('<time><span>**Hello**</span></time>'));
 
-            it('processes inline HTML with inline styles', () => {
-                render(compiler('<span style="color: red; position: top; margin-right: 10px">Hello</span>'));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+      it('processes markdown within nested inline HTML where childen appear more than once', () => {
+        render(
+          compiler('<dl><dt>foo</dt><dd>bar</dd><dt>baz</dt><dd>qux</dd></dl>')
+        );
 
-            it('processes markdown within block-level arbitrary HTML', () => {
-                render(compiler('<p>**Hello**</p>'));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+      it('processes attributes within inline HTML', () => {
+        render(compiler('<time data-foo="bar">Hello</time>'));
 
-            it('renders inline <code> tags', () => {
-                render(compiler('Text and <code>**code**</code>'));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+      it('processes attributes that need JSX massaging within inline HTML', () => {
+        render(compiler('<span tabindex="0">Hello</span>'));
 
-            it('handles self-closing html inside parsable html (regression)', () => {
-                render(compiler('<a href="https://opencollective.com/react-dropzone/sponsor/0/website" target="_blank"><img src="https://opencollective.com/react-dropzone/sponsor/0/avatar.svg"></a>'));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+      it('processes inline HTML with inline styles', () => {
+        render(
+          compiler(
+            '<span style="color: red; position: top; margin-right: 10px">Hello</span>'
+          )
+        );
 
-            it('throws out HTML comments', () => {
-                render(compiler('Foo\n<!-- blah -->'));
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+      it('processes markdown within block-level arbitrary HTML', () => {
+        render(compiler('<p>**Hello**</p>'));
 
-            it('block HTML regression test', () => {
-                render(compiler(`
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+
+      it('renders inline <code> tags', () => {
+        render(compiler('Text and <code>**code**</code>'));
+
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+
+      it('handles self-closing html inside parsable html (regression)', () => {
+        render(
+          compiler(
+            '<a href="https://opencollective.com/react-dropzone/sponsor/0/website" target="_blank"><img src="https://opencollective.com/react-dropzone/sponsor/0/avatar.svg"></a>'
+          )
+        );
+
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+
+      it('throws out HTML comments', () => {
+        render(compiler('Foo\n<!-- blah -->'));
+
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+
+      it('block HTML regression test', () => {
+        render(
+          compiler(`
 <ul id="ProjectSubmenu">
     <li><a href="/projects/markdown/" title="Markdown Project Page">Main</a></li>
     <li><a href="/projects/markdown/basics" title="Markdown Basics">Basics</a></li>
@@ -513,19 +484,23 @@ describe('markdown-to-jsx', () => {
     <li><a href="/projects/markdown/license" title="Pricing and License Information">License</a></li>
     <li><a href="/projects/markdown/dingus" title="Online Markdown Web Form">Dingus</a></li>
 </ul>
-`));
+`)
+        );
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('handles svg', () => {
-                render(compiler(fs.readFileSync(__dirname + '/docs/images/logo.svg', 'utf8')));
+      it('handles svg', () => {
+        render(
+          compiler(fs.readFileSync(__dirname + '/docs/images/logo.svg', 'utf8'))
+        );
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('handles nested HTML blocks of the same type (regression)', () => {
-                render(compiler(`
+      it('handles nested HTML blocks of the same type (regression)', () => {
+        render(
+          compiler(`
 <table>
     <tbody>
       <tr>
@@ -549,13 +524,15 @@ describe('markdown-to-jsx', () => {
       </tr>
     </tbody>
 </table>
-                `));
+                `)
+        );
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('regression test for #136', () => {
-                render(compiler(`
+      it('regression test for #136', () => {
+        render(
+          compiler(`
 $25
   <br>
   <br>
@@ -569,345 +546,375 @@ $25
   <br>
   <br>
   <br>
-                `));
+                `)
+        );
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('#140 self-closing HTML with indentation', () => {
-                function DatePicker () { return <div className="datepicker" />; }
+      it('#140 self-closing HTML with indentation', () => {
+        function DatePicker() {
+          return <div className="datepicker" />;
+        }
 
-                render(compiler([
-                    '<DatePicker ',
-                    '    biasTowardDateTime="2017-12-05T07:39:36.091Z"',
-                    '    timezone="UTC+5"',
-                    '/>',
-                ].join('\n'), { overrides: { DatePicker }}));
+        render(
+          compiler(
+            [
+              '<DatePicker ',
+              '    biasTowardDateTime="2017-12-05T07:39:36.091Z"',
+              '    timezone="UTC+5"',
+              '/>'
+            ].join('\n'),
+            { overrides: { DatePicker } }
+          )
+        );
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('handles jsx attribute interpolation as a string', () => {
-                function DatePicker ({ endTime, startTime }) {
-                    return <div>{startTime} to {endTime}</div>;
-                }
+      it('handles jsx attribute interpolation as a string', () => {
+        function DatePicker({ endTime, startTime }) {
+          return (
+            <div>
+              {startTime} to {endTime}
+            </div>
+          );
+        }
 
-                render(compiler([
-                    '<DatePicker ',
-                    '    startTime={1514579720511}',
-                    '    endTime={"1514579720512"}',
-                    '/>',
-                ].join('\n'), { overrides: { DatePicker }}));
+        render(
+          compiler(
+            [
+              '<DatePicker ',
+              '    startTime={1514579720511}',
+              '    endTime={"1514579720512"}',
+              '/>'
+            ].join('\n'),
+            { overrides: { DatePicker } }
+          )
+        );
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
 
-            it('handles jsx inside jsx interpolations', () => {
-                function InterpolationTest ({ component, component2, component3, component4 }) {
-                    return (
-                        <div>{component} and {component2} and {component3} and {component4}</div>
-                    );
-                }
+      it('handles jsx inside jsx interpolations', () => {
+        function InterpolationTest({
+          component,
+          component2,
+          component3,
+          component4
+        }) {
+          return (
+            <div>
+              {component} and {component2} and {component3} and {component4}
+            </div>
+          );
+        }
 
-                function Inner ({ children, ...props }) {
-                    return <div {...props} className="inner">{children}</div>;
-                }
+        function Inner({ children, ...props }) {
+          return (
+            <div {...props} className="inner">
+              {children}
+            </div>
+          );
+        }
 
-                render(compiler([
-                    '<InterpolationTest ',
-                    '    component={<Inner children="bah" />}',
-                    '    component2={<Inner>blah</Inner>}',
-                    '    component3={<Inner disabled />}',
-                    '    component4={<Inner disabled={false} />}',
-                    '/>',
-                ].join('\n'), { overrides: { Inner, InterpolationTest }}));
+        render(
+          compiler(
+            [
+              '<InterpolationTest ',
+              '    component={<Inner children="bah" />}',
+              '    component2={<Inner>blah</Inner>}',
+              '    component3={<Inner disabled />}',
+              '    component4={<Inner disabled={false} />}',
+              '/>'
+            ].join('\n'),
+            { overrides: { Inner, InterpolationTest } }
+          )
+        );
 
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
-
-        describe('horizontal rules', () => {
-            it('should handle the various syntaxes', () => {
-                render(compiler([
-                    '* * *',
-                    '***',
-                    '*****',
-                    '- - -',
-                    '---------------------------------------',
-                ].join('\n\n')));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
-
-        describe('line breaks', () => {
-            it('should be added for 2-space sequences', () => {
-                render(compiler([
-                    'hello  ',
-                    'there',
-                ].join('\n')));
-
-                const lineBreak = root.querySelector('br');
-
-                expect(lineBreak).not.toBe(null);
-            });
-        });
-
-        describe('fenced code blocks', () => {
-            it('should be handled', () => {
-                render(compiler([
-                    '```js',
-                    'foo',
-                    '```',
-                ].join('\n')));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
-
-        describe('indented code blocks', () => {
-            it('should be handled', () => {
-                render(compiler('    foo\n\n'));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
-
-        describe('inline code blocks', () => {
-            it('should be handled', () => {
-                render(compiler('`foo`'));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
-
-        describe('footnotes', () => {
-            it('should handle conversion of references into links', () => {
-                render(compiler([
-                    'foo[^abc] bar',
-                    '',
-                    '[^abc]: Baz baz',
-                ].join('\n')));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-
-            it('should inject the definitions in a footer at the end of the root', () => {
-                render(compiler([
-                    'foo[^abc] bar',
-                    '',
-                    '[^abc]: Baz baz',
-                ].join('\n')));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-
-            it('should handle single word footnote definitions', () => {
-                render(compiler([
-                    'foo[^abc] bar',
-                    '',
-                    '[^abc]: Baz',
-                ].join('\n')));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
-
-        describe('options.forceBlock', () => {
-            it('treats given markdown as block-context', () => {
-                render(compiler('Hello. _Beautiful_ day isn\'t it?', { forceBlock: true }));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
-
-        describe('options.forceInline', () => {
-            it('treats given markdown as inline-context, passing through any block-level markdown syntax', () => {
-                render(compiler('# You got it babe!', { forceInline: true }));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
-
-        describe('overrides', () => {
-            it('should substitute the appropriate JSX tag if given a component', () => {
-                class FakeParagraph extends React.Component {
-                    render () {
-                        return (
-                            <p className='foo'>{this.props.children}</p>
-                        );
-                    }
-                }
-
-                render(
-                    compiler('Hello.\n\n', {overrides: {p: {component: FakeParagraph}}})
-                );
-
-                expect(root.children[0].className).toBe('foo');
-                expect(root.children[0].textContent).toBe('Hello.');
-            });
-
-            it('should accept an override shorthand if props do not need to be overidden', () => {
-                class FakeParagraph extends React.Component {
-                    render () {
-                        return (
-                            <p className='foo'>{this.props.children}</p>
-                        );
-                    }
-                }
-
-                render(
-                    compiler('Hello.\n\n', {overrides: {p: FakeParagraph}})
-                );
-
-                expect(root.children[0].className).toBe('foo');
-                expect(root.children[0].textContent).toBe('Hello.');
-            });
-
-            it('should add props to the appropriate JSX tag if supplied', () => {
-                render(
-                    compiler('Hello.\n\n', {overrides: {p: {props: {className: 'abc'}}}})
-                );
-
-                expect(root.children[0].className).toBe('abc');
-                expect(root.children[0].textContent).toBe('Hello.');
-            });
-
-            it('should add props to pre & code tags if supplied', () => {
-                render(
-                    compiler([
-                        '```',
-                        'foo',
-                        '```',
-                    ].join('\n'), {
-                        overrides: {
-                            code: {
-                                props: {
-                                    'data-foo': 'bar',
-                                },
-                            },
-
-                            pre: {
-                                props: {
-                                    className: 'abc',
-                                },
-                            },
-                        },
-                    })
-                );
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-
-            it('should substitute pre & code tags if supplied with an override component', () => {
-                class OverridenPre extends React.Component {
-                    render () {
-                        const {children, ...props} = this.props;
-
-                        return (
-                            <pre {...props} data-bar='baz'>{children}</pre>
-                        );
-                    }
-                }
-
-                class OverridenCode extends React.Component {
-                    render () {
-                        const {children, ...props} = this.props;
-
-                        return (
-                            <code {...props} data-baz='fizz'>{children}</code>
-                        );
-                    }
-                }
-
-                render(
-                    compiler([
-                        '```',
-                        'foo',
-                        '```',
-                    ].join('\n'), {
-                        overrides: {
-                            code: {
-                                component: OverridenCode,
-                                props: {
-                                    'data-foo': 'bar',
-                                },
-                            },
-
-                            pre: {
-                                component: OverridenPre,
-                                props: {
-                                    className: 'abc',
-                                },
-                            },
-                        },
-                    })
-                );
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-
-            it('should be able to override gfm task list items', () => {
-                render(compiler('- [ ] foo', {overrides: {li: {props: {className: 'foo'}}}}));
-                const $element = root.querySelector('li');
-
-                expect($element.outerHTML).toMatchSnapshot();
-            });
-
-            it('should be able to override gfm task list item checkboxes', () => {
-                render(compiler('- [ ] foo', {overrides: {input: {props: {className: 'foo'}}}}));
-                const $element = root.querySelector('input');
-
-                expect($element.outerHTML).toMatchSnapshot();
-            });
-        });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
     });
 
-    describe('component', () => {
-        it('accepts markdown content', () => {
-            render(<Markdown>_Hello._</Markdown>);
+    describe('horizontal rules', () => {
+      it('should handle the various syntaxes', () => {
+        render(
+          compiler(
+            [
+              '* * *',
+              '***',
+              '*****',
+              '- - -',
+              '---------------------------------------'
+            ].join('\n\n')
+          )
+        );
 
-            expect(root.innerHTML).toMatchSnapshot();
-        });
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
 
-        it('handles a no-children scenario', () => {
-            render(<Markdown>{''}</Markdown>);
+    describe('line breaks', () => {
+      it('should be added for 2-space sequences', () => {
+        render(compiler(['hello  ', 'there'].join('\n')));
 
-            expect(root.innerHTML).toMatchSnapshot();
-        });
+        const lineBreak = root.querySelector('br');
 
-        it('accepts options', () => {
-            class FakeParagraph extends React.Component {
-                render () {
-                    return (
-                        <p className='foo'>{this.props.children}</p>
-                    );
+        expect(lineBreak).not.toBe(null);
+      });
+    });
+
+    describe('fenced code blocks', () => {
+      it('should be handled', () => {
+        render(compiler(['```js', 'foo', '```'].join('\n')));
+
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
+
+    describe('indented code blocks', () => {
+      it('should be handled', () => {
+        render(compiler('    foo\n\n'));
+
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
+
+    describe('inline code blocks', () => {
+      it('should be handled', () => {
+        render(compiler('`foo`'));
+
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
+
+    describe('footnotes', () => {
+      it('should handle conversion of references into links', () => {
+        render(compiler(['foo[^abc] bar', '', '[^abc]: Baz baz'].join('\n')));
+
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+
+      it('should inject the definitions in a footer at the end of the root', () => {
+        render(compiler(['foo[^abc] bar', '', '[^abc]: Baz baz'].join('\n')));
+
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+
+      it('should handle single word footnote definitions', () => {
+        render(compiler(['foo[^abc] bar', '', '[^abc]: Baz'].join('\n')));
+
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
+
+    describe('options.forceBlock', () => {
+      it('treats given markdown as block-context', () => {
+        render(
+          compiler("Hello. _Beautiful_ day isn't it?", { forceBlock: true })
+        );
+
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
+
+    describe('options.forceInline', () => {
+      it('treats given markdown as inline-context, passing through any block-level markdown syntax', () => {
+        render(compiler('# You got it babe!', { forceInline: true }));
+
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+    });
+
+    describe('overrides', () => {
+      it('should substitute the appropriate JSX tag if given a component', () => {
+        class FakeParagraph extends React.Component {
+          render() {
+            return <p className="foo">{this.props.children}</p>;
+          }
+        }
+
+        render(
+          compiler('Hello.\n\n', {
+            overrides: { p: { component: FakeParagraph } }
+          })
+        );
+
+        expect(root.children[0].className).toBe('foo');
+        expect(root.children[0].textContent).toBe('Hello.');
+      });
+
+      it('should accept an override shorthand if props do not need to be overidden', () => {
+        class FakeParagraph extends React.Component {
+          render() {
+            return <p className="foo">{this.props.children}</p>;
+          }
+        }
+
+        render(compiler('Hello.\n\n', { overrides: { p: FakeParagraph } }));
+
+        expect(root.children[0].className).toBe('foo');
+        expect(root.children[0].textContent).toBe('Hello.');
+      });
+
+      it('should add props to the appropriate JSX tag if supplied', () => {
+        render(
+          compiler('Hello.\n\n', {
+            overrides: { p: { props: { className: 'abc' } } }
+          })
+        );
+
+        expect(root.children[0].className).toBe('abc');
+        expect(root.children[0].textContent).toBe('Hello.');
+      });
+
+      it('should add props to pre & code tags if supplied', () => {
+        render(
+          compiler(['```', 'foo', '```'].join('\n'), {
+            overrides: {
+              code: {
+                props: {
+                  'data-foo': 'bar'
                 }
+              },
+
+              pre: {
+                props: {
+                  className: 'abc'
+                }
+              }
             }
+          })
+        );
 
-            render(
-                <Markdown options={{overrides: {p: {component: FakeParagraph}}}}>
-                    _Hello._
-                </Markdown>
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+
+      it('should substitute pre & code tags if supplied with an override component', () => {
+        class OverridenPre extends React.Component {
+          render() {
+            const { children, ...props } = this.props;
+
+            return (
+              <pre {...props} data-bar="baz">
+                {children}
+              </pre>
             );
+          }
+        }
 
-            expect(root.innerHTML).toMatchSnapshot();
-        });
+        class OverridenCode extends React.Component {
+          render() {
+            const { children, ...props } = this.props;
 
-        it('merges className overrides, rather than overwriting', () => {
-            const code = [
-                '```js',
-                'foo',
-                '```',
-            ].join('\n');
-
-            render(
-                <Markdown options={{overrides: {code: {props: {className: 'foo'}}}}}>
-                    {code}
-                </Markdown>
+            return (
+              <code {...props} data-baz="fizz">
+                {children}
+              </code>
             );
+          }
+        }
 
-            expect(root.innerHTML).toMatchSnapshot();
-        });
+        render(
+          compiler(['```', 'foo', '```'].join('\n'), {
+            overrides: {
+              code: {
+                component: OverridenCode,
+                props: {
+                  'data-foo': 'bar'
+                }
+              },
+
+              pre: {
+                component: OverridenPre,
+                props: {
+                  className: 'abc'
+                }
+              }
+            }
+          })
+        );
+
+        expect(root.innerHTML).toMatchSnapshot();
+      });
+
+      it('should be able to override gfm task list items', () => {
+        render(
+          compiler('- [ ] foo', {
+            overrides: { li: { props: { className: 'foo' } } }
+          })
+        );
+        const $element = root.querySelector('li');
+
+        expect($element.outerHTML).toMatchSnapshot();
+      });
+
+      it('should be able to override gfm task list item checkboxes', () => {
+        render(
+          compiler('- [ ] foo', {
+            overrides: { input: { props: { className: 'foo' } } }
+          })
+        );
+        const $element = root.querySelector('input');
+
+        expect($element.outerHTML).toMatchSnapshot();
+      });
     });
+
+    describe('react overrides', () => {
+      it('should substitute the Markdown output if given a react prop', () => {
+        render(
+          compiler('`hey`', {
+            react: { codeInline: () => <p className="foo">Test</p> }
+          })
+        );
+
+        expect(root.children[0].className).toBe('foo');
+        expect(root.children[0].textContent).toBe('Test');
+      });
+    });
+  });
+
+  describe('component', () => {
+    it('accepts markdown content', () => {
+      render(<Markdown>_Hello._</Markdown>);
+
+      expect(root.innerHTML).toMatchSnapshot();
+    });
+
+    it('handles a no-children scenario', () => {
+      render(<Markdown>{''}</Markdown>);
+
+      expect(root.innerHTML).toMatchSnapshot();
+    });
+
+    it('accepts options', () => {
+      class FakeParagraph extends React.Component {
+        render() {
+          return <p className="foo">{this.props.children}</p>;
+        }
+      }
+
+      render(
+        <Markdown options={{ overrides: { p: { component: FakeParagraph } } }}>
+          _Hello._
+        </Markdown>
+      );
+
+      expect(root.innerHTML).toMatchSnapshot();
+    });
+
+    it('merges className overrides, rather than overwriting', () => {
+      const code = ['```js', 'foo', '```'].join('\n');
+
+      render(
+        <Markdown
+          options={{ overrides: { code: { props: { className: 'foo' } } } }}>
+          {code}
+        </Markdown>
+      );
+
+      expect(root.innerHTML).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
While `options.overrrides` allows you to override the output for individual HTML components, `options.react` gives you complete flexibility to return any React component you want for each Markdown rule (`text`, `codeBlock`...). This is useful if you're trying to add custom syntatical sugar to some Markdown type. This PR will merge both the default rules and the passed ones only if the original rule is present and it has a defined `react` function.

This was discussed on #143 because I needed to override the `react()` function to return plain strings on the server via `react-dom/server`.

I've also added a test for this functionality.