### PR TITLE
JSX now preserves new lines in examples using template literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ renders
 <h1>Hello world!</h1>
 ```
 
+**NOTE: JSX without template literals does not natively preserve newlines in multiline text. It's a good idea to keep your content in .md files and require them, perhaps using webpack's [raw-loader](https://github.com/webpack-contrib/raw-loader).**
+
 ### Parsing Options
 
 #### options.forceBlock

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ But this string would be considered "block" due to the existence of a header tag
 However, if you really want all input strings to be treated as "block" layout, simply pass `options.forceBlock = true` like this:
 
 ```jsx
-<Markdown options={{ forceBlock: true }}>
-    Hello there old chap!
-</Markdown>
+<Markdown options={{ forceBlock: true }}>{`
+Hello there old chap!
+`}</Markdown>
 
 // or
 
@@ -106,9 +106,9 @@ compiler('Hello there old chap!', { forceBlock: true });
 The inverse is also available by passing `options.forceInline = true`:
 
 ```jsx
-<Markdown options={{ forceInline: true }}>
-    # You got it babe!
-</Markdown>
+<Markdown options={{ forceInline: true }}>{`
+# You got it babe!
+`}</Markdown>
 
 // or
 
@@ -142,9 +142,9 @@ render((
                     },
                 },
             },
-        }}>
-        # Hello world!
-    </Markdown>
+        }}>{`
+# Hello world!
+    `}</Markdown>
 ), document.body);
 
 /*

--- a/README.md
+++ b/README.md
@@ -51,29 +51,25 @@ yarn add markdown-to-jsx
 
 `markdown-to-jsx` exports a React component by default for easy JSX composition:
 
-ES6-style usage\*:
-
 ```jsx
 import Markdown from 'markdown-to-jsx';
 import React from 'react';
 import {render} from 'react-dom';
 
-const markdown = `# Hello world!`.trim();
-
 render((
-    <Markdown>
-        # Hello world!
-    </Markdown>
+    <Markdown>{`
+
+# Hello world!
+
+    `}</Markdown>
 ), document.body);
-
-/*
-    renders:
-
-    <h1>Hello world!</h1>
- */
 ```
 
-\* __NOTE: JSX does not natively preserve newlines in multiline text. In general, writing markdown directly in JSX is discouraged and it's a better idea to keep your content in separate .md files and require them, perhaps using webpack's [raw-loader](https://github.com/webpack-contrib/raw-loader).__
+renders
+
+```html
+<h1>Hello world!</h1>
+```
 
 ### Parsing Options
 


### PR DESCRIPTION
see https://github.com/pravdomil/markdown-to-jsx/blob/patch-5/README.md#usage