### PR TITLE
workaround for parsing block html inside arbitrary html

### DIFF
--- a/__snapshots__/index.spec.js.snap
+++ b/__snapshots__/index.spec.js.snap
@@ -542,6 +542,20 @@ exports[`markdown-to-jsx compiler arbitrary HTML processes inline HTML with inli
 
 `;
 
+exports[`markdown-to-jsx compiler arbitrary HTML processes markdown within block-level arbitrary HTML (regression) 1`] = `
+
+<div data-reactroot
+     style="float: right;"
+>
+  <h1>
+    <!-- react-text: 3 -->
+    Hello
+    <!-- /react-text -->
+  </h1>
+</div>
+
+`;
+
 exports[`markdown-to-jsx compiler arbitrary HTML processes markdown within block-level arbitrary HTML 1`] = `
 
 <p data-reactroot>
@@ -771,7 +785,7 @@ exports[`markdown-to-jsx compiler footnotes should inject the definitions in a f
 
 `;
 
-exports[`markdown-to-jsx compiler handles a hollistic example 1`] = `
+exports[`markdown-to-jsx compiler handles a holistic example 1`] = `
 
 <div data-reactroot>
   <h1>

--- a/__snapshots__/index.spec.js.snap
+++ b/__snapshots__/index.spec.js.snap
@@ -415,6 +415,21 @@ exports[`markdown-to-jsx compiler arbitrary HTML handles jsx inside jsx interpol
 
 `;
 
+exports[`markdown-to-jsx compiler arbitrary HTML handles malformed HTML 1`] = `
+
+<div data-reactroot>
+  <g>
+  </g>
+  <g>
+    <path fill="#ffffff">
+    </path>
+  </g>
+  <path fill="#ffffff">
+  </path>
+</div>
+
+`;
+
 exports[`markdown-to-jsx compiler arbitrary HTML handles nested HTML blocks of the same type (regression) 1`] = `
 
 <table data-reactroot>

--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ const CODE_BLOCK_R = /^(?: {4}[^\n]+\n*)+(?:\n *)+\n/;
 const CODE_INLINE_R = /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/;
 const CONSECUTIVE_NEWLINE_R = /^(?:\n *)*\n/;
 const CR_NEWLINE_R = /\r\n?/g;
+const DETECT_BLOCK_SYNTAX = /(^[-*] |^#+|^ {2,}|^-{2,}|^> )/m;
 const FOOTNOTE_R = /^\[\^(.*)\](:.*)\n/;
 const FOOTNOTE_REFERENCE_R = /^\[\^(.*)\]/;
 const FORMFEED_R = /\f/g;
@@ -151,6 +152,7 @@ const PARAGRAPH_R = /^((?:[^\n]|\n(?! *\n))+)(?:\n *)+\n/;
 const REFERENCE_IMAGE_OR_LINK = /^\[([^\]]*)\]:\s*(\S+)\s*("([^"]*)")?/;
 const REFERENCE_IMAGE_R = /^!\[([^\]]*)\] ?\[([^\]]*)\]/;
 const REFERENCE_LINK_R = /^\[([^\]]*)\] ?\[([^\]]*)\]/;
+const SHOULD_RENDER_AS_BLOCK_R = /(\n|^[-*]\s|^#|^ {2,}|^-{2,}|^>\s)/;
 const TAB_R = /\t/g;
 const TABLE_TRIM_PIPES = /(^ *\||\| *$)/g;
 const TABLE_CENTER_ALIGN = /^ *:-+: *$/;
@@ -163,6 +165,14 @@ const TEXT_ESCAPED_R = /^\\([^0-9A-Za-z\s])/;
 const TEXT_PLAIN_R = /^[\s\S]+?(?=[^0-9A-Z\s\u00c0-\uffff]|\d+\.|\n\n| {2,}\n|\w+:\S|$)/i;
 const TEXT_STRIKETHROUGHED_R = /^~~(?=\S)([\s\S]*?\S)~~/;
 const TRIM_NEWLINES_AND_TRAILING_WHITESPACE_R = /(^\n+|(\n|\s)+$)/g;
+
+/**
+ * Indented-style code blocks cannot be used inside arbitrary HTML at this time because
+ * it's not clear if the indentation is intentional or just there from how the composer
+ * laid things out.
+ */
+const TRIM_HTML = /^\s*| {4,}|\s*$/g;
+
 const UNESCAPE_URL_R = /\\([^0-9A-Z\s])/gi;
 
 // recognize a `*` `-`, `+`, `1.`, `2.`... list bullet
@@ -626,7 +636,7 @@ export function compiler (markdown, options) {
             * should not contain any block-level markdown like newlines, lists, headings,
             * thematic breaks, blockquotes, tables, etc
             */
-            inline = /(\n|^[-*]\s|^#|^ {2,}|^-{2,}|^>\s)/g.test(input) === false;
+            inline = SHOULD_RENDER_AS_BLOCK_R.test(input) === false;
         }
 
         const arr = emitter(
@@ -899,7 +909,9 @@ export function compiler (markdown, options) {
             match: anyScopeRegex(HTML_BLOCK_ELEMENT_R),
             order: PARSE_PRIORITY_HIGH,
             parse (capture, parse, state) {
-                const parseFunc = capture[3].match(HTML_BLOCK_ELEMENT_R) ? parseBlock : parseInline;
+                const parseFunc = (
+                    capture[3].match(HTML_BLOCK_ELEMENT_R) || DETECT_BLOCK_SYNTAX.test(capture[3])
+                ) ? parseBlock : parseInline;
 
                 return {
                     attrs: attrStringToMap(capture[2]),
@@ -907,7 +919,7 @@ export function compiler (markdown, options) {
                      * if another html block is detected within, parse as block,
                      * otherwise parse as inline to pick up any further markdown
                      */
-                    content: parseFunc(parse, capture[3].trim(), state),
+                    content: parseFunc(parse, capture[3].replace(TRIM_HTML, ''), state),
 
                     tag: capture[1],
                 };

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ const HEADING_SETEXT_R = /^([^\n]+)\n *(=|-){3,} *(?:\n *)+\n/;
  * 6. Capture excess newlines afterward
  *    \n*
  */
-const HTML_BLOCK_ELEMENT_R = /^ *<([^ >/]+) ?([^>]*)\/{0}>(?=[\s\S]*<\/\1>)((?:[\s\S]*?(?:<\1[^>]*>[\s\S]*?<\/\1>)*[\s\S]*?)*?)<\/\1>\n*/;
+const HTML_BLOCK_ELEMENT_R = /^ *<([^ >/]+) ?([^>]*)\/{0}>\s*((?:<\1>[\s\S]*<\/\1>|(?!<\1)[\s\S])*)<\/\1>\n*/;
 
 const HTML_COMMENT_R = /^<!--.*?-->/;
 

--- a/index.spec.js
+++ b/index.spec.js
@@ -40,7 +40,7 @@ describe('markdown-to-jsx', () => {
             expect(root.innerHTML).toMatchSnapshot();
         });
 
-        it('handles a hollistic example', () => {
+        it('handles a holistic example', () => {
             const md = fs.readFileSync(__dirname + '/fixture.md', 'utf8');
             render(compiler(md));
 
@@ -482,6 +482,12 @@ describe('markdown-to-jsx', () => {
 
             it('processes markdown within block-level arbitrary HTML', () => {
                 render(compiler('<p>**Hello**</p>'));
+
+                expect(root.innerHTML).toMatchSnapshot();
+            });
+
+            it('processes markdown within block-level arbitrary HTML (regression)', () => {
+                render(compiler('<div style="float: right">\n# Hello\n</div>'));
 
                 expect(root.innerHTML).toMatchSnapshot();
             });

--- a/index.spec.js
+++ b/index.spec.js
@@ -630,6 +630,18 @@ $25
 
                 expect(root.innerHTML).toMatchSnapshot();
             });
+
+            it('handles malformed HTML', () => {
+                render(compiler([
+                    '<g>',
+                    '<g>',
+                    '<path fill="#ffffff"/>',
+                    '</g>',
+                    '<path fill="#ffffff"/>',
+                ].join('\n')));
+
+                expect(root.innerHTML).toMatchSnapshot();
+            });
         });
 
         describe('horizontal rules', () => {


### PR DESCRIPTION
partially fixes #153 

not 100% happy with this at the moment, as it technically fixes an edge case and introduces a new one (though a less frequent one)