### PR TITLE
Support spaces between equal sign for html attributes

### DIFF
--- a/__snapshots__/index.spec.js.snap
+++ b/__snapshots__/index.spec.js.snap
@@ -694,6 +694,21 @@ exports[`markdown-to-jsx compiler arbitrary HTML throws out HTML comments 1`] = 
 
 `;
 
+exports[`markdown-to-jsx compiler arbitrary HTML allows whitespace between attribute and value 1`] = `
+
+<div data-reactroot
+     class="foo"
+     id="baz"
+     style="background: red;"
+>
+  <!-- react-text: 2 -->
+  Bar
+  <!-- /react-text -->
+</div>
+
+`;
+
+
 exports[`markdown-to-jsx compiler fenced code blocks should be handled 1`] = `
 
 <pre data-reactroot>

--- a/index.js
+++ b/index.js
@@ -672,7 +672,7 @@ export function compiler (markdown, options) {
     function attrStringToMap (str) {
         const attributes = str.match(ATTR_EXTRACTOR_R);
 
-        const out = attributes ? attributes.reduce(function (map, raw, index) {
+        return attributes ? attributes.reduce(function (map, raw, index) {
             const delimiterIdx = raw.indexOf('=');
 
             if (delimiterIdx !== -1) {
@@ -696,8 +696,6 @@ export function compiler (markdown, options) {
 
             return map;
         }, {}) : undefined;
-
-        return out
     }
 
     /* istanbul ignore next */

--- a/index.js
+++ b/index.js
@@ -672,12 +672,12 @@ export function compiler (markdown, options) {
     function attrStringToMap (str) {
         const attributes = str.match(ATTR_EXTRACTOR_R);
 
-        return attributes ? attributes.reduce(function (map, raw, index) {
+        const out = attributes ? attributes.reduce(function (map, raw, index) {
             const delimiterIdx = raw.indexOf('=');
 
             if (delimiterIdx !== -1) {
-                const key = normalizeAttributeKey(raw.slice(0, delimiterIdx));
-                const value = unquote(raw.slice(delimiterIdx + 1));
+                const key = normalizeAttributeKey(raw.slice(0, delimiterIdx)).trim();
+                const value = unquote(raw.slice(delimiterIdx + 1).trim());
 
                 const mappedKey = ATTRIBUTE_TO_JSX_PROP_MAP[key] || key;
                 const normalizedValue = map[mappedKey] = attributeValueToJSXPropValue(key, value);
@@ -696,6 +696,8 @@ export function compiler (markdown, options) {
 
             return map;
         }, {}) : undefined;
+
+        return out
     }
 
     /* istanbul ignore next */

--- a/index.spec.js
+++ b/index.spec.js
@@ -642,6 +642,17 @@ $25
 
                 expect(root.innerHTML).toMatchSnapshot();
             });
+
+            it('allows whitespace between attribute and value', () => {
+                render(compiler([
+                    '<div class = "foo" style= "background:red;" id ="baz">',
+                    'Bar',
+                    '</div>'
+                    ].join('\n')))
+
+                expect(root.innerHTML).toMatchSnapshot();
+            });
+
         });
 
         describe('horizontal rules', () => {


### PR DESCRIPTION
Even with regex and comments supporting whitespaces between attributes and values (`<tag key = val />`), the code itself does not account for these spaces and includes them into final strings generating inconsistent parsing like `"foo` instead of `foo` or ` class` instead of `class`...

I added very lightweight change to `trim()` leading and trailing spaces if any.
See #161 

Plus I wrote test cases to prevent any future regression.