### PR TITLE
breaking: remove forceBlock mode, make it the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ render((
 
 #### options.forceInline
 
-Sometimes you just want to parse markdown inside a basic container without block-level syntaxes. Perhaps to allow some really simple user inputted link tags, bolding, etc. `options.forceInline = true` enforces an inline-only syntax mode to handle these use cases.
+Sometimes you just want to parse markdown inside a basic container without block-level syntaxes, perhaps to allow some really simple user inputted link tags, bolding, etc. `options.forceInline = true` enforces an inline-only syntax mode to handle these use cases.
 
 ```jsx
 <Markdown options={{ forceInline: true }}>
@@ -91,6 +91,9 @@ compiler('# You got it babe!', { forceInline: true });
 // renders
 
 <span># You got it babe!</span>
+
+// note that the heading syntax (#) is considered a block-level
+// markdown construct and is left as-is in inline mode
 ```
 
 #### options.overrides - Override Any HTML Tag's Representation

--- a/README.md
+++ b/README.md
@@ -71,7 +71,17 @@ render((
  */
 ```
 
-\* __NOTE: JSX does not natively preserve newlines in multiline text. In general, writing markdown directly in JSX is discouraged and it's a better idea to keep your content in separate .md files and require them, perhaps using webpack's [raw-loader](https://github.com/webpack-contrib/raw-loader).__
+__NOTE: JSX does not natively preserve newlines in multiline text. In general, writing markdown directly in JSX is discouraged and it's a better idea to keep your content in separate .md files and require them, perhaps using webpack's [raw-loader](https://github.com/webpack-contrib/raw-loader).__
+
+That being said, you can also achieve preserved, multiline text in JSX by using a template literal:
+
+```jsx
+<Markdown>{`
+    # Hello world!
+
+    Here's some arbitrary text.
+`}</Markdown>
+```
 
 ### Parsing Options
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
     - [Installation](#installation)
     - [Usage](#usage)
         - [Parsing Options](#parsing-options)
-            - [options.forceBlock](#optionsforceblock)
             - [options.forceInline](#optionsforceinline)
             - [options.overrides - Override Any HTML Tag's Representation](#optionsoverrides---override-any-html-tags-representation)
             - [options.overrides - Rendering Arbitrary React Components](#optionsoverrides---rendering-arbitrary-react-components)
@@ -76,37 +75,9 @@ render((
 
 ### Parsing Options
 
-#### options.forceBlock
-By default, the compiler will try to make an intelligent guess about the content passed and wrap it in a `<div>`, `<p>`, or `<span>` as needed to satisfy the "inline"-ness of the markdown. For instance, this string would be considered "inline":
-
-```md
-Hello. _Beautiful_ day isn't it?
-```
-
-But this string would be considered "block" due to the existence of a header tag, which is a block-level HTML element:
-
-```md
-# Whaddup?
-```
-
-However, if you really want all input strings to be treated as "block" layout, simply pass `options.forceBlock = true` like this:
-
-```jsx
-<Markdown options={{ forceBlock: true }}>
-    Hello there old chap!
-</Markdown>
-
-// or
-
-compiler('Hello there old chap!', { forceBlock: true });
-
-// renders
-
-<p>Hello there old chap!</p>
-```
-
 #### options.forceInline
-The inverse is also available by passing `options.forceInline = true`:
+
+Sometimes you just want to parse markdown inside a basic container without block-level syntaxes. Perhaps to allow some really simple user inputted link tags, bolding, etc. `options.forceInline = true` enforces an inline-only syntax mode to handle these use cases.
 
 ```jsx
 <Markdown options={{ forceInline: true }}>

--- a/__snapshots__/index.spec.js.snap
+++ b/__snapshots__/index.spec.js.snap
@@ -537,14 +537,14 @@ exports[`markdown-to-jsx compiler arbitrary HTML regression test for #136 1`] = 
 
 exports[`markdown-to-jsx compiler arbitrary HTML renders inline <code> tags 1`] = `
 
-<span data-reactroot>
+<p data-reactroot>
   Text and
   <code>
     <strong>
       code
     </strong>
   </code>
-</span>
+</p>
 
 `;
 
@@ -2460,9 +2460,9 @@ exports[`markdown-to-jsx compiler horizontal rules should handle the various syn
 
 exports[`markdown-to-jsx compiler images should handle a basic image 1`] = `
 
-<img data-reactroot
-     src="/xyz.png"
->
+<p data-reactroot>
+  <img src="/xyz.png">
+</p>
 
 `;
 
@@ -2497,20 +2497,22 @@ exports[`markdown-to-jsx compiler images should handle an image reference with t
 
 exports[`markdown-to-jsx compiler images should handle an image with alt text 1`] = `
 
-<img data-reactroot
-     alt="test"
-     src="/xyz.png"
->
+<p data-reactroot>
+  <img alt="test"
+       src="/xyz.png"
+  >
+</p>
 
 `;
 
 exports[`markdown-to-jsx compiler images should handle an image with title 1`] = `
 
-<img data-reactroot
-     alt="test"
-     title="foo"
-     src="/xyz.png"
->
+<p data-reactroot>
+  <img alt="test"
+       title="foo"
+       src="/xyz.png"
+  >
+</p>
 
 `;
 
@@ -2526,91 +2528,103 @@ exports[`markdown-to-jsx compiler indented code blocks should be handled 1`] = `
 
 exports[`markdown-to-jsx compiler inline code blocks should be handled 1`] = `
 
-<code data-reactroot>
-  foo
-</code>
+<p data-reactroot>
+  <code>
+    foo
+  </code>
+</p>
 
 `;
 
 exports[`markdown-to-jsx compiler inline textual elements should handle deleted text 1`] = `
 
-<del data-reactroot>
-  Hello.
-</del>
+<p data-reactroot>
+  <del>
+    Hello.
+  </del>
+</p>
 
 `;
 
 exports[`markdown-to-jsx compiler inline textual elements should handle double-emphasized text 1`] = `
 
-<strong data-reactroot>
-  Hello.
-</strong>
+<p data-reactroot>
+  <strong>
+    Hello.
+  </strong>
+</p>
 
 `;
 
 exports[`markdown-to-jsx compiler inline textual elements should handle emphasized text 1`] = `
 
-<em data-reactroot>
-  Hello.
-</em>
+<p data-reactroot>
+  <em>
+    Hello.
+  </em>
+</p>
 
 `;
 
 exports[`markdown-to-jsx compiler inline textual elements should handle escaped text 1`] = `
 
-<span data-reactroot>
+<p data-reactroot>
   Hello.__foo__
-</span>
+</p>
 
 `;
 
 exports[`markdown-to-jsx compiler inline textual elements should handle the alternate form of bold/italic 1`] = `
 
-<strong data-reactroot>
-  <em>
-    Hello.
-  </em>
-</strong>
+<p data-reactroot>
+  <strong>
+    <em>
+      Hello.
+    </em>
+  </strong>
+</p>
 
 `;
 
 exports[`markdown-to-jsx compiler inline textual elements should handle triple-emphasized text 1`] = `
 
-<strong data-reactroot>
-  <em>
-    Hello.
-  </em>
-</strong>
+<p data-reactroot>
+  <strong>
+    <em>
+      Hello.
+    </em>
+  </strong>
+</p>
 
 `;
 
 exports[`markdown-to-jsx compiler links should an email autolink and add a mailto: prefix 1`] = `
 
-<a data-reactroot
-   href="mailto:probablyup@gmail.com"
->
-  probablyup@gmail.com
-</a>
+<div data-reactroot>
+  <a href="mailto:probablyup@gmail.com">
+    probablyup@gmail.com
+  </a>
+</div>
 
 `;
 
 exports[`markdown-to-jsx compiler links should automatically link found URLs 1`] = `
 
-<a data-reactroot
-   href="https://google.com"
->
-  https://google.com
-</a>
+<p data-reactroot>
+  <a href="https://google.com">
+    https://google.com
+  </a>
+</p>
 
 `;
 
 exports[`markdown-to-jsx compiler links should handle a basic link 1`] = `
 
-<a data-reactroot
-   href="/xyz.png"
->
-  foo
-</a>
+<p data-reactroot>
+  <a href="/xyz.png">
+    foo
+  </a>
+</p>
 
 `;
 
@@ -2648,61 +2662,66 @@ exports[`markdown-to-jsx compiler links should handle a link reference with titl
 
 exports[`markdown-to-jsx compiler links should handle a link with a URL in the text 1`] = `
 
-<a data-reactroot
-   href="http://www.google.com"
->
-  https://www.google.com
-  <em>
-    heck yeah
-  </em>
-</a>
+<p data-reactroot>
+  <a href="http://www.google.com">
+    https://www.google.com
+    <em>
+      heck yeah
+    </em>
+  </a>
+</p>
 
 `;
 
 exports[`markdown-to-jsx compiler links should handle a link with title 1`] = `
 
-<a data-reactroot
-   href="/xyz.png"
-   title="bar"
->
-  foo
-</a>
+<p data-reactroot>
+  <a href="/xyz.png"
+     title="bar"
+  >
+    foo
+  </a>
+</p>
 
 `;
 
 exports[`markdown-to-jsx compiler links should handle a mailto autolink 1`] = `
 
-<a data-reactroot
-   href="mailto:probablyup@gmail.com"
->
-  probablyup@gmail.com
-</a>
+<div data-reactroot>
+  <a href="mailto:probablyup@gmail.com">
+    probablyup@gmail.com
+  </a>
+</div>
 
 `;
 
 exports[`markdown-to-jsx compiler links should handle autolink style 1`] = `
 
-<a data-reactroot
-   href="https://google.com"
->
-  https://google.com
-</a>
+<div data-reactroot>
+  <a href="https://google.com">
+    https://google.com
+  </a>
+</div>
 
 `;
 
 exports[`markdown-to-jsx compiler links should sanitize links containing JS expressions 1`] = `
 
-<a data-reactroot>
-  foo
-</a>
+<p data-reactroot>
+  <a>
+    foo
+  </a>
+</p>
 
 `;
 
 exports[`markdown-to-jsx compiler links should sanitize links containing invalid characters 1`] = `
 
-<a data-reactroot>
-  foo
-</a>
+<p data-reactroot>
+  <a>
+    foo
+  </a>
+</p>
 
 `;
 
@@ -2937,18 +2956,6 @@ exports[`markdown-to-jsx compiler misc block level elements should handle blockq
 
 `;
 
-exports[`markdown-to-jsx compiler options.forceBlock treats given markdown as block-context 1`] = `
-
-<p data-reactroot>
-  Hello.
-  <em>
-    Beautiful
-  </em>
-  day isn't it?
-</p>
-
-`;
-
 exports[`markdown-to-jsx compiler options.forceInline treats given markdown as inline-context, passing through any block-level markdown syntax 1`] = `
 
 <span data-reactroot>
@@ -3017,31 +3024,37 @@ exports[`markdown-to-jsx compiler wraps multiple block element returns in a div 
 
 `;
 
-exports[`markdown-to-jsx compiler wraps solely inline elements in a span, rather than a div 1`] = `
+exports[`markdown-to-jsx compiler wraps solely inline elements in a p, rather than a div 1`] = `
 
-<span data-reactroot>
+<p data-reactroot>
   Hello.
   <em>
     Beautiful
   </em>
   day isn't it?
-</span>
+</p>
 
 `;
 
 exports[`markdown-to-jsx component accepts markdown content 1`] = `
 
-<em data-reactroot>
-  Hello.
-</em>
+<p data-reactroot>
+  <em>
+    Hello.
+  </em>
+</p>
 
 `;
 
 exports[`markdown-to-jsx component accepts options 1`] = `
 
-<em data-reactroot>
-  Hello.
-</em>
+<p data-reactroot
+   class="foo"
+>
+  <em>
+    Hello.
+  </em>
+</p>
 
 `;
 

--- a/index.js
+++ b/index.js
@@ -677,17 +677,7 @@ export function compiler (markdown, options) {
     }
 
     function compile (input) {
-        let inline = false;
-
-        if (options.forceInline) {
-            inline = true;
-        } else if (!options.forceBlock) {
-            /**
-            * should not contain any block-level markdown like newlines, lists, headings,
-            * thematic breaks, blockquotes, tables, etc
-            */
-            inline = SHOULD_RENDER_AS_BLOCK_R.test(input) === false;
-        }
+        const inline = !!options.forceInline;
 
         const arr = emitter(
             parser(
@@ -1060,7 +1050,7 @@ export function compiler (markdown, options) {
 
         // https://daringfireball.net/projects/markdown/syntax#autolink
         linkAngleBraceStyleDetector: {
-            match: inlineRegex(LINK_AUTOLINK_R),
+            match: anyScopeRegex(LINK_AUTOLINK_R),
             order: PARSE_PRIORITY_MAX,
             parse (capture/*, parse, state*/) {
                 return {
@@ -1091,7 +1081,7 @@ export function compiler (markdown, options) {
         },
 
         linkMailtoDetector: {
-            match: inlineRegex(LINK_AUTOLINK_MAILTO_R),
+            match: anyScopeRegex(LINK_AUTOLINK_MAILTO_R),
             order: PARSE_PRIORITY_MAX,
             parse (capture/*, parse, state*/) {
                 let address = capture[1];

--- a/index.js
+++ b/index.js
@@ -152,7 +152,6 @@ const PARAGRAPH_R = /^((?:[^\n]|\n(?! *\n))+)(?:\n *)+\n/;
 const REFERENCE_IMAGE_OR_LINK = /^\[([^\]]*)\]:\s*(\S+)\s*("([^"]*)")?/;
 const REFERENCE_IMAGE_R = /^!\[([^\]]*)\] ?\[([^\]]*)\]/;
 const REFERENCE_LINK_R = /^\[([^\]]*)\] ?\[([^\]]*)\]/;
-const SHOULD_RENDER_AS_BLOCK_R = /(\n|^[-*]\s|^#|^ {2,}|^-{2,}|^>\s)/;
 const TAB_R = /\t/g;
 const TABLE_TRIM_PIPES = /(^ *\||\| *$)/g;
 const TABLE_CENTER_ALIGN = /^ *:-+: *$/;

--- a/index.spec.js
+++ b/index.spec.js
@@ -34,7 +34,7 @@ describe('markdown-to-jsx', () => {
             expect(root.innerHTML).toMatchSnapshot();
         });
 
-        it('wraps solely inline elements in a span, rather than a div', () => {
+        it('wraps solely inline elements in a p, rather than a div', () => {
             render(compiler('Hello. _Beautiful_ day isn\'t it?'));
 
             expect(root.innerHTML).toMatchSnapshot();
@@ -762,14 +762,6 @@ $25
                     '',
                     '[^abc]: Baz',
                 ].join('\n')));
-
-                expect(root.innerHTML).toMatchSnapshot();
-            });
-        });
-
-        describe('options.forceBlock', () => {
-            it('treats given markdown as block-context', () => {
-                render(compiler('Hello. _Beautiful_ day isn\'t it?', { forceBlock: true }));
 
                 expect(root.innerHTML).toMatchSnapshot();
             });


### PR DESCRIPTION
This aligns usage and expected output to the community standards around markdown rendering... no more trying to be clever about it.