### PR TITLE
fix block-level syntax inference inside arbitrary HTML

### DIFF
--- a/__snapshots__/index.spec.js.snap
+++ b/__snapshots__/index.spec.js.snap
@@ -297,6 +297,32 @@ exports[`markdown-to-jsx compiler arbitrary HTML block HTML regression test 1`] 
 
 `;
 
+exports[`markdown-to-jsx compiler arbitrary HTML handles a heading inside HTML 1`] = `
+
+<span data-reactroot>
+  "
+  <span>
+    <h1 id="foo">
+      foo
+    </h1>
+  </span>
+  "
+</span>
+
+`;
+
+exports[`markdown-to-jsx compiler arbitrary HTML handles a raw hashtag inside HTML 1`] = `
+
+<span data-reactroot>
+  "
+  <span>
+    #
+  </span>
+  "
+</span>
+
+`;
+
 exports[`markdown-to-jsx compiler arbitrary HTML handles jsx attribute interpolation as a string 1`] = `
 
 <div data-reactroot>

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ const CODE_BLOCK_R = /^(?: {4}[^\n]+\n*)+(?:\n *)+\n/;
 const CODE_INLINE_R = /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/;
 const CONSECUTIVE_NEWLINE_R = /^(?:\n *)*\n/;
 const CR_NEWLINE_R = /\r\n?/g;
-const DETECT_BLOCK_SYNTAX = /(^[-*] |^#+|^ {2,}|^-{2,}|^> )/m;
+const DETECT_BLOCK_SYNTAX = /(^[-*] |^#+ ?\w|^ {2,}|^-{2,}|^> )/m;
 const FOOTNOTE_R = /^\[\^(.*)\](:.*)\n/;
 const FOOTNOTE_REFERENCE_R = /^\[\^(.*)\]/;
 const FORMFEED_R = /\f/g;
@@ -1356,7 +1356,7 @@ export function compiler (markdown, options) {
             // double newlines, or double-space-newlines
             // We break on any symbol characters so that this grammar
             // is easy to extend without needing to modify this regex
-            match: simpleInlineRegex(TEXT_PLAIN_R),
+            match: anyScopeRegex(TEXT_PLAIN_R),
             order: PARSE_PRIORITY_MIN,
             parse (capture/*, parse, state*/) {
                 return {

--- a/index.spec.js
+++ b/index.spec.js
@@ -678,6 +678,21 @@ $25
                 expect(root.innerHTML).toMatchSnapshot();
             });
 
+            it('handles a raw hashtag inside HTML', () => {
+                render(compiler([
+                    '"<span>#</span>"',
+                ].join('\n')));
+
+                expect(root.innerHTML).toMatchSnapshot();
+            });
+
+            it('handles a heading inside HTML', () => {
+                render(compiler([
+                    '"<span># foo</span>"',
+                ].join('\n')));
+
+                expect(root.innerHTML).toMatchSnapshot();
+            });
         });
 
         describe('horizontal rules', () => {


### PR DESCRIPTION
Fixes #168 