### PR TITLE
Enable non-alphanumeric characters to have id in headings

### DIFF
--- a/__snapshots__/index.spec.js.snap
+++ b/__snapshots__/index.spec.js.snap
@@ -2530,6 +2530,26 @@ exports[`markdown-to-jsx compiler headings should handle level 6 properly 1`] = 
 
 `;
 
+exports[`markdown-to-jsx compiler headings should handle mix of alphanumeric and non-alphanumeric characters 1`] = `
+
+<h1 data-reactroot
+    id="%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF%E4%B8%96%E7%95%8C-hello-world-123"
+>
+  こんにちは世界  hello  world　123
+</h1>
+
+`;
+
+exports[`markdown-to-jsx compiler headings should handle non-alphanumeric characters 1`] = `
+
+<h1 data-reactroot
+    id="%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF%E4%B8%96%E7%95%8C"
+>
+  こんにちは世界
+</h1>
+
+`;
+
 exports[`markdown-to-jsx compiler headings should handle setext level 1 style 1`] = `
 
 <div data-reactroot>

--- a/index.js
+++ b/index.js
@@ -221,10 +221,13 @@ const IMAGE_R = new RegExp(
     '^!\\[(' + LINK_INSIDE + ')\\]\\(' + LINK_HREF_AND_TITLE + '\\)'
 );
 
+const ENCODED_CHARS = /%(\w){2}/g;
+const ENCODED_SPACE_CHARS = /(%20|%E3%80%80)+/g;
+
 // based on https://stackoverflow.com/a/18123682/1141611
 // not complete, but probably good enough
 function slugify (str) {
-    return str
+    const s =  str
         .replace(/[ÀÁÂÃÄÅàáâãäåæÆ]/g,'a')
         .replace(/[çÇ]/g,'c')
         .replace(/[ðÐ]/g,'d')
@@ -234,10 +237,16 @@ function slugify (str) {
         .replace(/[øØœŒÕõÔôÓóÒò]/g,'o')
         .replace(/[ÜüÛûÚúÙù]/g,'u')
         .replace(/[ŸÿÝý]/g,'y')
-        .replace(/[^a-z0-9- ]/gi,'')
-        .replace(/ /gi,'-')
-        .toLowerCase()
     ;
+
+    return encodeURIComponent(s)
+        .replace(ENCODED_SPACE_CHARS, '+')
+        .replace(/[^a-z0-9-%+]/gi,'')
+        .replace(/\+/gi,'-')
+        .toLowerCase()
+        .replace(ENCODED_CHARS, match => match.toUpperCase())
+    ;
+
 }
 
 function parseTableAlignCapture (alignCapture) {

--- a/index.spec.js
+++ b/index.spec.js
@@ -147,6 +147,18 @@ describe('markdown-to-jsx', () => {
 
                 expect(root.innerHTML).toMatchSnapshot();
             });
+
+            it('should handle non-alphanumeric characters', () => {
+                render(compiler('# こんにちは世界'));
+
+                expect(root.innerHTML).toMatchSnapshot();
+            })
+
+            it('should handle mix of alphanumeric and non-alphanumeric characters', () => {
+                render(compiler('# こんにちは世界  hello  world　123'));
+
+                expect(root.innerHTML).toMatchSnapshot();
+            });
         });
 
         describe('images', () => {


### PR DESCRIPTION
This PR resolves #177 .

I've changed the logic of `slugify()` and written test cases for the change. 