### PR TITLE
[XSS] Ignore case of blacklisted HTML elements

### DIFF
--- a/index.compiler.spec.js
+++ b/index.compiler.spec.js
@@ -2392,6 +2392,18 @@ $25
 `);
   });
 
+  it('does not parse the inside of <script> blocks with weird capitalization', () => {
+    render(compiler(['<SCRIPT>', '  new Date();', '</SCRIPT>'].join('\n')));
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+
+<script data-reactroot>
+  new Date();
+</script>
+
+`);
+  });
+
   it('handles nested tags of the same type with attributes', () => {
     render(
       compiler(

--- a/index.js
+++ b/index.js
@@ -1025,9 +1025,9 @@ export function compiler(markdown, options) {
           ? parseBlock
           : parseInline;
 
-        const tag = capture[1].toLowerCase();
+        const tagName = capture[1].toLowerCase();
         const noInnerParse =
-          DO_NOT_PROCESS_HTML_ELEMENTS.indexOf(tag) !== -1;
+          DO_NOT_PROCESS_HTML_ELEMENTS.indexOf(tagName) !== -1;
 
         return {
           attrs: attrStringToMap(capture[2]),
@@ -1039,7 +1039,7 @@ export function compiler(markdown, options) {
 
           noInnerParse,
 
-          tag
+          tag: noInnerParse ? tagName : capture[1]
         };
       },
       react(node, output, state) {

--- a/index.js
+++ b/index.js
@@ -1025,8 +1025,9 @@ export function compiler(markdown, options) {
           ? parseBlock
           : parseInline;
 
+        const tag = capture[1].toLowerCase();
         const noInnerParse =
-          DO_NOT_PROCESS_HTML_ELEMENTS.indexOf(capture[1]) !== -1;
+          DO_NOT_PROCESS_HTML_ELEMENTS.indexOf(tag) !== -1;
 
         return {
           attrs: attrStringToMap(capture[2]),
@@ -1038,7 +1039,7 @@ export function compiler(markdown, options) {
 
           noInnerParse,
 
-          tag: capture[1],
+          tag
         };
       },
       react(node, output, state) {


### PR DESCRIPTION
Right now, you can inject `script` and `style` tags by using uppercase letters, e.g. `<SCRIPT>alert('hi')</SCRIPT>`. This PR converts tag names to lowercase before evaluating against the blacklist.