### PR TITLE
Sanitize `href` values

### DIFF
--- a/index.compiler.spec.js
+++ b/index.compiler.spec.js
@@ -909,7 +909,7 @@ describe('links', () => {
 `);
   });
 
-  it('should sanitize links containing JS expressions', () => {
+  it('should sanitize markdown links containing JS expressions', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     render(compiler('[foo](javascript:doSomethingBad)'));
@@ -925,7 +925,7 @@ describe('links', () => {
     expect(console.warn).toHaveBeenCalled();
   });
 
-  it('should sanitize links containing encoded JS expressions', () => {
+  it('should sanitize markdown links containing encoded JS expressions', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     render(compiler('[foo](javascript%3AdoSomethingBad)'));
@@ -941,7 +941,7 @@ describe('links', () => {
     expect(console.warn).toHaveBeenCalled();
   });
 
-  it('should sanitize links containing padded JS expressions', () => {
+  it('should sanitize markdown links containing padded JS expressions', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     render(compiler('[foo](  javascript%3AdoSomethingBad)'));
@@ -957,7 +957,7 @@ describe('links', () => {
     expect(console.warn).toHaveBeenCalled();
   });
 
-  it('should sanitize links containing invalid characters', () => {
+  it('should sanitize markdown links containing invalid characters', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     render(compiler('[foo](https://google.com/%AF)'));
@@ -971,6 +971,22 @@ describe('links', () => {
 `);
     expect(console.warn).toHaveBeenCalled();
   });
+
+  it('should sanitize html links containing JS expressions', () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      render(compiler('<a href="javascript:doSomethingBad">foo</a>'));
+
+      expect(root.innerHTML).toMatchInlineSnapshot(`
+
+<a data-reactroot>
+  foo
+</a>
+
+`);
+
+      expect(console.warn).toHaveBeenCalled();
+    });
 
   it('should handle a link with a URL in the text', () => {
     render(

--- a/index.js
+++ b/index.js
@@ -374,6 +374,8 @@ function attributeValueToJSXPropValue(key, value) {
 
       return styles;
     }, {});
+  } else if (key === 'href') {
+    return sanitizeUrl(value)
   } else if (value.match(INTERPOLATION_R)) {
     // return as a string and let the consumer decide what to do with it
     value = value.slice(1, value.length - 1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3891,13 +3891,13 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^1.0.0, fsevents@^1.2.3, fsevents@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.7.tgz#4851b664a3783e52003b3c66eb0eee1074933aa4"
-  integrity sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==
+fsevents@^1.0.0, fsevents@^1.2.3, fsevents@^1.2.7, fsevents@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.9.tgz#3f5ed66583ccd6f400b5a00db6f7e861363e388f"
+  integrity sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==
   dependencies:
-    nan "^2.9.2"
-    node-pre-gyp "^0.10.0"
+    nan "^2.12.1"
+    node-pre-gyp "^0.12.0"
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -6005,10 +6005,10 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nan@^2.9.2:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.1.tgz#a15bee3790bde247e8f38f1d446edcdaeb05f2dd"
-  integrity sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA==
+nan@^2.12.1:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
+  integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -6129,10 +6129,10 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@^0.10.0:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
-  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
+node-pre-gyp@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
+  integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"


### PR DESCRIPTION
Previously links like `<a href="javascript:alert('hi')">Foo</a>` were passed through unsanitized while `[javascript:alert('hi')](Foo)` was sanitized. This change makes both sanitized, and also escapes any other `href` attributes.

This fixes #239. This also includes a change to prevent element name case from subverting the HTML element blacklist. 