### PR TITLE
Keep text following line-starting HTML tag in paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+**Deprecated**
+I tried to solve https://github.com/probablyup/markdown-to-jsx/issues/220 : Newline was lost if last element of the line is an HTML one.
+Unfortunately, I didn't find any acceptable solution.
+
+_Possible workaround:_
+( Using https://github.com/probablyup/markdown-to-jsx )
+I personally use a (ugly) workaround on my local project: I append `*<span></span>*` after each custom html element which is at a end of line. Because the issue doesn't hit text bolded with markdown, I use this property.
+
+
 **markdown-to-jsx**
 
 The most lightweight, customizable React markdown component.

--- a/index.compiler.spec.js
+++ b/index.compiler.spec.js
@@ -63,15 +63,23 @@ it('wraps solely inline elements in a span, rather than a div', () => {
 });
 
 it('wraps solely begining or ending inline elements together with following paragraph', () => {
-  render(compiler("#Hey\n<ins>Insertion before text</ins> followed by some text"));
-
-console.log(root.innerHTML);
+  render(compiler("#Hey\n<ins>Insertion before text</ins> followed by some text <del>not anymore finishing by other text</del>"));
 
   expect(root.innerHTML).toMatchInlineSnapshot(`
 
 <div data-reactroot>
-  <h1>Hey</h1>
-  <p><ins>Insertion before text</ins> followed by some text</p>
+  <h1 id="hey">
+    Hey
+  </h1>
+  <p>
+    <ins>
+      Insertion before text
+    </ins>
+    followed by some text
+    <del>
+      not anymore finishing by other text
+    </del>
+  </p>
 </div>
 
 `);

--- a/index.compiler.spec.js
+++ b/index.compiler.spec.js
@@ -62,6 +62,21 @@ it('wraps solely inline elements in a span, rather than a div', () => {
 `);
 });
 
+it('wraps solely begining or ending inline elements together with following paragraph', () => {
+  render(compiler("#Hey\n<ins>Insertion before text</ins> followed by some text"));
+
+console.log(root.innerHTML);
+
+  expect(root.innerHTML).toMatchInlineSnapshot(`
+
+<div data-reactroot>
+  <h1>Hey</h1>
+  <p><ins>Insertion before text</ins> followed by some text</p>
+</div>
+
+`);
+});
+
 it('#190 perf regression', () => {
   render(
     compiler(

--- a/index.compiler.spec.js
+++ b/index.compiler.spec.js
@@ -84,6 +84,25 @@ it('wraps solely begining or ending inline elements together with following para
 
 `);
 });
+it('wraps solely begining or ending elements together with following paragraph when inline props is set', () => {
+  render(compiler("#Hey\n<a href=\"#\" inline>Inline insertion before text</a> followed by some text"));
+
+  expect(root.innerHTML).toMatchInlineSnapshot(`
+
+<div data-reactroot>
+  <h1 id="hey">
+    Hey
+  </h1>
+  <p>
+    <a href="#">
+      Inline insertion before text
+    </a>
+    followed by some text
+  </p>
+</div>
+
+`);
+});
 
 it('#190 perf regression', () => {
   render(

--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ function containsBlockSyntax(input) {
   return BLOCK_SYNTAXES.some(r => r.test(input));
 }
 
-const SIMPLE_TAGNAMES = [];  // Not currently used
+// const SIMPLE_TAGNAMES = [];  // Not currently used
 
 const INLINE_TAGNAMES = [  // This is a list of tag wich by wrapped by arounding paragraph. Does not apply to HTML element already wrapped.
   'abbr',

--- a/index.js
+++ b/index.js
@@ -282,8 +282,7 @@ function isInlineElement(inputTagName) {
 }
 function hasInlineTag(tags) {
   if(tags) {
-    console.log(tags, tags.match(/("\ |^)inline(\/?$|\ )/i))
-    return !!tags.match(/("\ |^)inline(\/?$|\ )/i);
+    return !!tags.match(/(" |^)inline(\/?$| )/i);
   }
   return false;
 }

--- a/index.js
+++ b/index.js
@@ -277,11 +277,10 @@ const INLINE_TAGNAMES = [  // This is a list of tag wich by wrapped by arounding
   'u'
 ];
 
-function isInlineElement(inputTagName) {
-  return INLINE_TAGNAMES.some(tagName => tagName == inputTagName);
-}
-function hasInlineProperty(properties) {
-  return (properties && properties.match(/(" |^)inline(\/?$| )/i)) || false;
+function isInlineElement(inputTagName, propertiesString) {
+  return INLINE_TAGNAMES.some(tagName => tagName == inputTagName)
+    || (propertiesString && propertiesString.match(/(" |^)inline(\/?$| )/i))  // has the `inline` property ?
+    || false;
 }
 // function isSimpleElement(inputTagName) {  // Not currently used
 //   return SIMPLE_TAGNAMES.some(tagName => tagName == inputTagName);
@@ -571,7 +570,7 @@ function htmlDependantScopeRegex(regex) {
   return function match(source, state) {
     const capture = regex.exec(source);
     if (capture) {
-      const isInline = isInlineElement(capture[1]) || hasInlineProperty(capture[2]);
+      const isInline = isInlineElement(capture[1], capture[2]);
       // const isSimple = isSimpleElement(capture[1]);  // Not currently used
       if (isInline && !state.inline) return null;
       // if (isSimple && !state.simple) return null;  // Not currently used

--- a/index.js
+++ b/index.js
@@ -280,6 +280,13 @@ const INLINE_TAGNAMES = [  // This is a list of tag wich by wrapped by arounding
 function isInlineElement(inputTagName) {
   return INLINE_TAGNAMES.some(tagName => tagName == inputTagName);
 }
+function hasInlineTag(tags) {
+  if(tags) {
+    console.log(tags, tags.match(/("\ |^)inline(\/?$|\ )/i))
+    return !!tags.match(/("\ |^)inline(\/?$|\ )/i);
+  }
+  return false;
+}
 // function isSimpleElement(inputTagName) {  // Not currently used
 //   return SIMPLE_TAGNAMES.some(tagName => tagName == inputTagName);
 // }
@@ -568,7 +575,7 @@ function htmlDependantScopeRegex(regex) {
   return function match(source, state) {
     const capture = regex.exec(source);
     if (capture) {
-      const isInline = isInlineElement(capture[1]);
+      const isInline = isInlineElement(capture[1]) || hasInlineTag(capture[2]);
       // const isSimple = isSimpleElement(capture[1]);  // Not currently used
       if (isInline && !state.inline) return null;
       // if (isSimple && !state.simple) return null;  // Not currently used

--- a/index.js
+++ b/index.js
@@ -280,11 +280,8 @@ const INLINE_TAGNAMES = [  // This is a list of tag wich by wrapped by arounding
 function isInlineElement(inputTagName) {
   return INLINE_TAGNAMES.some(tagName => tagName == inputTagName);
 }
-function hasInlineTag(tags) {
-  if(tags) {
-    return !!tags.match(/(" |^)inline(\/?$| )/i);
-  }
-  return false;
+function hasInlineProperty(properties) {
+  return (properties && properties.match(/(" |^)inline(\/?$| )/i)) || false;
 }
 // function isSimpleElement(inputTagName) {  // Not currently used
 //   return SIMPLE_TAGNAMES.some(tagName => tagName == inputTagName);
@@ -574,7 +571,7 @@ function htmlDependantScopeRegex(regex) {
   return function match(source, state) {
     const capture = regex.exec(source);
     if (capture) {
-      const isInline = isInlineElement(capture[1]) || hasInlineTag(capture[2]);
+      const isInline = isInlineElement(capture[1]) || hasInlineProperty(capture[2]);
       // const isSimple = isSimpleElement(capture[1]);  // Not currently used
       if (isInline && !state.inline) return null;
       // if (isSimple && !state.simple) return null;  // Not currently used


### PR DESCRIPTION
Notes:
- It will only works with a predefined list of html elements or
- Now with component with `inline` props set, like: (Tests will be writed shortly)
``` javascript

compiler(`<Abbr title="JS" text="JavaScript" inline/>`),
  {
    overrides: {
      Abbr: {
          component: Abbr
      }
    }
  }
);
```
