### PR TITLE
Fix TRIM_NEWLINES_AND_TRAILING_WHITESPACE_R regex bug

### DIFF
--- a/index.compiler.spec.js
+++ b/index.compiler.spec.js
@@ -2702,6 +2702,28 @@ fun main() {
 
 `);
   });
+ it('should not fail with lots of \\n in the middle of the text', () => {
+    render(
+      compiler(
+        'Text\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\ntext',
+        {
+          forceBlock: true,
+        }
+      )
+    );
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+
+<div data-reactroot>
+  <p>
+    Text
+  </p>
+  <p>
+    text
+  </p>
+</div>
+
+`);
+  });
 });
 
 describe('horizontal rules', () => {

--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ const TEXT_STRIKETHROUGHED_R = /^~~((?:\[.*?\]|<.*?>(?:.*?<.*?>)?|`.*?`|.)*?)~~/
 
 const TEXT_ESCAPED_R = /^\\([^0-9A-Za-z\s])/;
 const TEXT_PLAIN_R = /^[\s\S]+?(?=[^0-9A-Z\s\u00c0-\uffff&;.()'"]|\d+\.|\n\n| {2,}\n|\w+:\S|$)/i;
-const TRIM_NEWLINES_AND_TRAILING_WHITESPACE_R = /(^\n+|(\n|\s)+$)/g;
+const TRIM_NEWLINES_AND_TRAILING_WHITESPACE_R = /(^\n+|\n+$|\s+$)/g;
 
 const HTML_LEFT_TRIM_AMOUNT_R = /^([ \t]*)/;
 


### PR DESCRIPTION
I found out if to pass to compiler string with consecutive `\n` in the middle of the text, then this replace doesn't work
```
`${input.replace(TRIM_NEWLINES_AND_TRAILING_WHITESPACE_R, '')}\n\n`,
```
There is an infinite loading. It happens only when the sequence of `\n` is longer than 25-30 symbols.

This bug was implemented in this commit https://github.com/probablyup/markdown-to-jsx/commit/bef82a5fa3f84fddb16b423f95f4930dfcbcf8e3 

I suppose that group inside the group in regex works very slow, that is why there is an infinite loading.

So in this PR I added the test of this case and simplified regex for TRIM_NEWLINES_AND_TRAILING_WHITESPACE_R