### PR TITLE
Fix #258: Allow escaping pipes within tables

### DIFF
--- a/index.compiler.spec.js
+++ b/index.compiler.spec.js
@@ -1698,6 +1698,89 @@ describe('GFM tables', () => {
 
 `);
   });
+
+  it('should handle escaped pipes inside a table', () => {
+    render(
+      compiler(
+        [
+          '| \\|Attribute\\| | \\|Type\\|         |',
+          '| --------------- | ------------------ |',
+          '| pos\\|position  | "left" \\| "right" |',
+        ].join('\n')
+      )
+    );
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+
+<table data-reactroot>
+  <thead>
+    <tr>
+      <th>
+        |Attribute|
+      </th>
+      <th>
+        |Type|
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        pos|position
+      </td>
+      <td>
+        "left" | "right"
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+`);
+  });
+
+  it('should handle pipes in code inside a table', () => {
+    render(
+      compiler(
+        [
+          '| Attribute    | Type                  |',
+          '| ------------ | --------------------- |',
+          '| `position`   | `"left" | "right"`    |',
+        ].join('\n')
+      )
+    );
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+
+<table data-reactroot>
+  <thead>
+    <tr>
+      <th>
+        Attribute
+      </th>
+      <th>
+        Type
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>
+          position
+        </code>
+      </td>
+      <td>
+        <code>
+          "left" | "right"
+        </code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+`);
+  });
+
 });
 
 describe('arbitrary HTML', () => {


### PR DESCRIPTION
Should fix #258

A port of https://github.com/Khan/simple-markdown/commit/f32a628401745787a2a199a5d3bde1efced4d6d5
to markdown-to-jsx.

Previously, tables were parsed using String.prototype.split on pipe
(`|`) characters.

This PR changes table parsing to use a full parse() call, using a
new `tableSeparator` rule to match tableSeparators. Because
`tableSeparator` is now a rule, the `escapedText` rule can handle
escaped pipes within the table, and the `codeInline` rule can handle
inline code with pipes in it.

Test plan:

Added tests to index.compiler.spec.js