### PR TITLE
Fix blank lines being required where they should not be. (#256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,13 +464,13 @@ The two leading spaces in front of "# Hello" would be left-trimmed from all line
 
 ✅
 
-```md
+~~~md
 <div>
 ```js
 var some = code();
 ```
 </div>
-```
+~~~
 
 ## Using The Compiler Directly
 

--- a/index.compiler.spec.js
+++ b/index.compiler.spec.js
@@ -626,6 +626,68 @@ describe('headings', () => {
 `);
   });
 
+  it('should handle a paragraph before a heading', () => {
+    render(compiler('Hello\nmulti-line paragraph\n# My Heading'));
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+
+<div data-reactroot>
+  <p>
+    Hello
+multi-line paragraph
+  </p>
+  <h1 id="my-heading">
+    My Heading
+  </h1>
+</div>
+
+`);
+  });
+
+  it('should handle a paragraph before a code block correctly', () => {
+    render(compiler('I am a paragraph\n```\ndo not break the code\n```'));
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+
+<div data-reactroot>
+  <p>
+    I am a paragraph
+  </p>
+  <pre>
+    <code>
+      do not break the code
+    </code>
+  </pre>
+</div>
+
+`);
+  })
+
+  it('should handle paragraphs next to lists correctly', () => {
+    render(compiler('Only one line - following this text\n  - I am a list item\n  - I am too\n\nnew paragraph'));
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+
+<div data-reactroot>
+  <p>
+    Only one line - following this text
+  </p>
+  <ul>
+    <li>
+      I am a list item
+    </li>
+    <li>
+      I am too
+    </li>
+  </ul>
+  <p>
+    new paragraph
+  </p>
+</div>
+
+`);
+  })
+
   it('adds an "id" attribute to headings for deeplinking purposes', () => {
     render(compiler("# This is~ a very' complicated> header!"));
 
@@ -3165,7 +3227,7 @@ describe('overrides', () => {
     );
 
     expect(root.children[0].className).toBe('foo');
-    expect(root.children[0].textContent).toBe('Hello.');
+    expect(root.children[0].textContent.trimRight()).toBe('Hello.');
   });
 
   it('should accept an override shorthand if props do not need to be overidden', () => {
@@ -3178,7 +3240,7 @@ describe('overrides', () => {
     render(compiler('Hello.\n\n', { overrides: { p: FakeParagraph } }));
 
     expect(root.children[0].className).toBe('foo');
-    expect(root.children[0].textContent).toBe('Hello.');
+    expect(root.children[0].textContent.trimRight()).toBe('Hello.');
   });
 
   it('should add props to the appropriate JSX tag if supplied', () => {
@@ -3189,7 +3251,7 @@ describe('overrides', () => {
     );
 
     expect(root.children[0].className).toBe('abc');
-    expect(root.children[0].textContent).toBe('Hello.');
+    expect(root.children[0].textContent.trimRight()).toBe('Hello.');
     expect(root.children[0].title).toBe('foo');
   });
 

--- a/index.compiler.spec.js
+++ b/index.compiler.spec.js
@@ -3416,7 +3416,7 @@ describe('overrides', () => {
     );
 
     expect(root.children[0].className).toBe('foo');
-    expect(root.children[0].textContent).toBe('Hello.');
+    expect(root.children[0].textContent.trimRight()).toBe('Hello.');
   });
 
   it('should substitute the appropriate JSX tag inline if given a component and disableParsingRawHTML is true', () => {

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ const LIST_ITEM_END_R = / *\n+$/;
 const LIST_LOOKBEHIND_R = /(?:^|\n)( *)$/;
 const CAPTURE_LETTER_AFTER_HYPHEN = /-([a-z])?/gi;
 const NP_TABLE_R = /^(.*\|?.*)\n *(\|? *[-:]+ *\|[-| :]*)\n((?:.*\|.*\n)*)\n?/;
-const PARAGRAPH_R = /^((?:[^\n]|\n(?! *\n))+)(?:\n *)+\n/;
+const PARAGRAPH_R = /^((?:[^\n]+\n)+?(?=\n|\s*(?:[-*+]|\d+\.)\s|#|>\s|`{3,}(?=[^`]*`{3,})))(?: *\n+|\n*)/;
 const REFERENCE_IMAGE_OR_LINK = /^\[([^\]]*)\]:\s*(\S+)\s*("([^"]*)")?/;
 const REFERENCE_IMAGE_R = /^!\[([^\]]*)\] ?\[([^\]]*)\]/;
 const REFERENCE_LINK_R = /^\[([^\]]*)\] ?\[([^\]]*)\]/;
@@ -729,7 +729,7 @@ export function compiler(markdown, options) {
   options = options || {};
   options.overrides = options.overrides || {};
   options.slugify = options.slugify || slugify;
-  options.namedCodesToUnicode = options.namedCodesToUnicode 
+  options.namedCodesToUnicode = options.namedCodesToUnicode
     ? {...namedCodesToUnicode, ...options.namedCodesToUnicode}
     : namedCodesToUnicode;
 

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ const LIST_ITEM_END_R = / *\n+$/;
 const LIST_LOOKBEHIND_R = /(?:^|\n)( *)$/;
 const CAPTURE_LETTER_AFTER_HYPHEN = /-([a-z])?/gi;
 const NP_TABLE_R = /^(.*\|?.*)\n *(\|? *[-:]+ *\|[-| :]*)\n((?:.*\|.*\n)*)\n?/;
-const PARAGRAPH_R = /^((?:[^\n]+\n)+?(?=\n|\s*(?:[-*+]|\d+\.)\s|#|>\s|[`~]{3,}(?=[^`~]*[`~]{3,})))(?: *\n+|\n*)/;
+const PARAGRAPH_R = /^((?:[^\n]+\n)+?(?=\n|\s*(?:[-*+]|\d{1,9}[.)])\s|#|>\s|[`~]{3,}(?=[^`~]*[`~]{3,})))(?: *\n+|\n*)/;
 const REFERENCE_IMAGE_OR_LINK = /^\[([^\]]*)\]:\s*(\S+)\s*("([^"]*)")?/;
 const REFERENCE_IMAGE_R = /^!\[([^\]]*)\] ?\[([^\]]*)\]/;
 const REFERENCE_LINK_R = /^\[([^\]]*)\] ?\[([^\]]*)\]/;

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ const LIST_ITEM_END_R = / *\n+$/;
 const LIST_LOOKBEHIND_R = /(?:^|\n)( *)$/;
 const CAPTURE_LETTER_AFTER_HYPHEN = /-([a-z])?/gi;
 const NP_TABLE_R = /^(.*\|?.*)\n *(\|? *[-:]+ *\|[-| :]*)\n((?:.*\|.*\n)*)\n?/;
-const PARAGRAPH_R = /^((?:[^\n]+\n)+?(?=\n|\s*(?:[-*+]|\d+\.)\s|#|>\s|`{3,}(?=[^`]*`{3,})))(?: *\n+|\n*)/;
+const PARAGRAPH_R = /^((?:[^\n]+\n)+?(?=\n|\s*(?:[-*+]|\d+\.)\s|#|>\s|[`~]{3,}(?=[^`~]*[`~]{3,})))(?: *\n+|\n*)/;
 const REFERENCE_IMAGE_OR_LINK = /^\[([^\]]*)\]:\s*(\S+)\s*("([^"]*)")?/;
 const REFERENCE_IMAGE_R = /^!\[([^\]]*)\] ?\[([^\]]*)\]/;
 const REFERENCE_LINK_R = /^\[([^\]]*)\] ?\[([^\]]*)\]/;


### PR DESCRIPTION
This fixes #256. For people who add a blank line after every paragraph, they should see no change. This change is to support broader flexibility so that a blank line is no longer mandatory in situations where a block follows a paragraph.

Other implementations of GitHub flavor markdown do not depend on these blank lines, so I see no reason that markdown-to-jsx should. A more flexible implementation makes markdown easier to write with more reliable results.