### PR TITLE
add test that demoes the deep nesting issue

### DIFF
--- a/index.compiler.spec.js
+++ b/index.compiler.spec.js
@@ -2183,6 +2183,24 @@ $25
 `);
   });
 
+  it('regression test for Deep Nesting issue', () => {
+    render(compiler(`<div><div><div><div>test</div></div></div></div>`));
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+
+<div data-reactroot>
+<div>
+  <div>
+    <div>
+      test
+    </div>
+  </div>
+</div>
+</div>
+
+`);
+  });
+
   it('regression test for #170', () => {
     render(
       compiler(


### PR DESCRIPTION
There is an issue with deeply nested HTML elements that can be seen by running the test in this PR.

The issue can also be seen by going to the [demo site](https://probablyup.com/markdown-to-jsx/) and adding the following HTML:

```
<div>
<div>
<div>
<div>
Test
</div>
</div>
</div>
</div>
```

The issue seems to have to do with the parser's inability to process html elements at are nested more than one level deep. The issue can also be seen be seen with intermingled elements: 

```
<p>
<div>
<p>
<div>
<p>
Test
</p>
</div>
</p>
</div>
</p>
```

In this case the `HTML_BLOCK_ELEMENT_R` will not match the closing `</p>`.

I believe the issue described in #255 is the same issue.