### PR TITLE
Added reference to transpile-md-to-json project

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ render(<Markdown># Hello world!</Markdown>, document.body);
  */
 ```
 
-\* **NOTE: JSX does not natively preserve newlines in multiline text. In general, writing markdown directly in JSX is discouraged and it's a better idea to keep your content in separate .md files and require them, perhaps using webpack's [raw-loader](https://github.com/webpack-contrib/raw-loader).**
+\* **NOTE: JSX does not natively preserve newlines in multiline text. In general, writing markdown directly in JSX is discouraged and it's a better idea to keep your content in separate .md files and require them, perhaps using webpack's [raw-loader](https://github.com/webpack-contrib/raw-loader) or [transpile-md-to-json](https://www.npmjs.com/package/transpile-md-to-json).**
 
 ### Parsing Options
 


### PR DESCRIPTION
The [transpile-md-to-json](https://www.npmjs.com/package/transpile-md-to-json) project was developed to transpile all markdown files in a given folder (recursively) to a single JSON file which can be imported in React and fed to markdown-to-jsx.