### PR TITLE
Fix: Support empty style attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -818,7 +818,7 @@ export function compiler(markdown, options) {
                 { key: index }
               );
             }
-          } else {
+          } else if (raw !== 'style') {
             map[ATTRIBUTE_TO_JSX_PROP_MAP[raw] || raw] = true;
           }
 


### PR DESCRIPTION
Fixes a bug in which empty style attributes result in unrecoverable JSX failures. For example:

```html
<div style>Foo</div>
```

Would result in the following console error:

```
Uncaught Invariant Violation: The `style` prop expects a
mapping from style properties to values, not a string.
For example, style={{marginRight: spacing + 'em'}} when
using JSX.
```

and the React JSX failing to render.

The problem is that empty properties are rendered as boolean `true` by default. This is consistent with HTML/React syntax interop expectations for most properties but not `style`, which expects an `Object` value in React-land.

Since an empty `style` attribute is semantically meaningless (where HTML is concerned) we can simply skip over this property.