### PR TITLE
Fix sanitizeUrl vbscript/data xss

### DIFF
--- a/index.js
+++ b/index.js
@@ -586,12 +586,13 @@ function reactFor(outputFunc) {
 
 function sanitizeUrl(url) {
   try {
-    const decoded = decodeURIComponent(url);
+    const decoded = decodeURIComponent(url)
+      .replace(/[^A-Za-z0-9/:]/g, '');
 
-    if (decoded.match(/^\s*javascript:/i)) {
+    if (decoded.match(/^\s*(javascript|vbscript|data):/i)) {
       if (process.env.NODE_ENV !== 'production') {
         console.warn(
-          'Anchor URL contains an unsafe JavaScript expression, it will not be rendered.',
+          'Anchor URL contains an unsafe JavaScript/VBScript/data expression, it will not be rendered.',
           decoded
         );
       }


### PR DESCRIPTION
Fixes #306 : I believe this fixes https://www.npmjs.com/advisories/1219 if
`options.disableParsingRawHTML` is set.

NOTE: This does not handle script elements, etc., that may be rendered
when `options.disableParsingRawHTML` is not enabled. We might be able to
use something like [`dompurify`](https://github.com/cure53/DOMPurify) to
solve that case?

According to https://owasp.org/www-community/xss-filter-evasion-cheatsheet ,
the dangerous `javascript:` protocol can contain some whitespace
characters and still be vulnerable, and sometimes when used in
conjunction with images, some other special characters like ` or <
before the javascript: protocol can also leave a url vulnerable.

This change re-adds the sanitiation logic removed in 9c6c782c , and also
adds the vbscript/data handling from github.com/Khan/simple-markdown/pull/63

Test plan:

Add tests and run `npm test`