### PR TITLE
Heading right after bullet

### DIFF
--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -569,6 +569,52 @@ describe('headings', () => {
       </h1>
     `)
   })
+  
+  it('Heading with link after bullet', () => {
+    render(compiler('- **bullet**\n# [Heading](http://domain.com) \n\n## Test'))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <div>
+        <ul>
+          <li>
+            <strong>
+              bullet
+            </strong>
+          </li>
+        </ul>
+        <h1 id="headinghttpdomaincom-">
+          <a href="http://domain.com">
+            Heading
+          </a>
+        </h1>
+        <h2 id="test">
+          Test
+        </h2>
+      </div>
+    `)
+  })
+
+  it('Heading after bullet', () => {
+    render(compiler('- **bullet**\n# Heading \n\n## Test'))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <div>
+        <ul>
+          <li>
+            <strong>
+              bullet
+            </strong>
+          </li>
+        </ul>
+        <h1 id="heading-">
+          Heading
+        </h1>
+        <h2 id="test">
+          Test
+        </h2>
+      </div>
+    `)
+  })
 })
 
 describe('images', () => {


### PR DESCRIPTION
Fixes #337

When H1 heading is right after the bullet (one new line between) compiler can't parse it as heading.

Exaple:
```
- **bullet**
# [Heading](http://domain.com) 

## Test
```
Every markdown editor, I can find, interpret this as heading.

Bellow GitHup interpretation with the same markup:
- **bullet**
# [Heading](http://domain.com) 

## Test