### PR TITLE
Don't emphasize snake_cased_words (fixes #352)

### DIFF
--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -348,6 +348,17 @@ describe('inline textual elements', () => {
     `)
   })
 
+  it('regression test for #352, snake_cased_words should not be emphasized', () => {
+    render(compiler('nothing_here_should_be_emphasized'))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <span>
+        nothing_here_should_be_emphasized
+      </span>
+    `)
+  })
+
+
   it('ignore similar syntax inside inline syntax', () => {
     render(
       compiler(

--- a/index.tsx
+++ b/index.tsx
@@ -331,6 +331,8 @@ const TABLE_LEFT_ALIGN = /^ *:-+ *$/
 const TABLE_RIGHT_ALIGN = /^ *-+: *$/
 
 const TEXT_BOLD_R = /^([*_])\1((?:\[.*?\][([].*?[)\]]|<.*?>(?:.*?<.*?>)?|`.*?`|~+.*?~+|.)*?)\1\1(?!\1)/
+
+const TEXT_EMPHASIZED_LOOKBEHIND_R = /[\w\d]$/
 const TEXT_EMPHASIZED_R = /^([*_])((?:\[.*?\][([].*?[)\]]|<.*?>(?:.*?<.*?>)?|`.*?`|~+.*?~+|.)*?)\1(?!\1)/
 const TEXT_STRIKETHROUGHED_R = /^~~((?:\[.*?\]|<.*?>(?:.*?<.*?>)?|`.*?`|.)*?)~~/
 
@@ -1652,7 +1654,19 @@ export function compiler(
     } as MarkdownToJSX.Rule<ReturnType<MarkdownToJSX.NestedParser>>,
 
     textEmphasized: {
-      match: simpleInlineRegex(TEXT_EMPHASIZED_R),
+      match(source, state, prevCapture) {
+
+        if (TEXT_EMPHASIZED_LOOKBEHIND_R.exec(prevCapture)) {
+          return null
+        }
+
+        if (state.inline || state.simple) {
+          return TEXT_EMPHASIZED_R.exec(source)
+        } else {
+          return null
+        }
+      },
+
       order: Priority.LOW,
       parse(capture, parse, state) {
         return {


### PR DESCRIPTION
`snake_cased_words` are currently rendered as `snake<em>cased</em>words`  

This PR uses prevCapture to perform a lookbehind and abort textEmphasis's matching if the last previously matched capture is not a word or digit (figured this would be safer than a-z to account for instances like 其_它_文_字 or 🍔_💅_🐛)

Fixes https://github.com/probablyup/markdown-to-jsx/issues/352