### PR TITLE
typescript typing: use React.ElementType rather than React.ComponentType

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -74,10 +74,10 @@ export namespace MarkdownToJSX {
 
   export type Override =
     | RequireAtLeastOne<{
-        component: React.ComponentType<any>
+        component: React.ElementType
         props: Object
       }>
-    | React.ComponentType<any>
+    | React.ElementType
 
   export type Overrides = {
     [tag in HTMLTags]?: Override


### PR DESCRIPTION
Currently providing overrides using intrinsic elements like

```tsx
p: {
  component: 'p',
  props: {
    className: 'inline',
  },
},
```
will result in a typescript error of `Type 'string' is not assignable to type 'ComponentType<any>'.`, even though it works

`React.ElementType` includes intrinsic elements and I believe is more appropriate here