### PR TITLE
#375 - Add null to possible types for wrapper.

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -147,7 +147,7 @@ export namespace MarkdownToJSX {
      * without any wrapper, or use `React.Fragment` to get a React element
      * that won't show up in the DOM.
      */
-    wrapper: React.ElementType
+    wrapper: React.ElementType | null
 
     /**
      * Forces the compiler to wrap results, even if there is only a single


### PR DESCRIPTION
This PR adds null to the possible types for `wrapper`. This type is already described in the documentation, so does not require any further changes.

Addresses #375 