### PR TITLE
Add additional option that allows for the extension of the markdown parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The most lightweight, customizable React markdown component.
     - [options.forceWrapper](#optionsforcewrapper)
     - [options.overrides - Override Any HTML Tag's Representation](#optionsoverrides---override-any-html-tags-representation)
     - [options.overrides - Rendering Arbitrary React Components](#optionsoverrides---rendering-arbitrary-react-components)
+    - [options.additionalParserRules - Parsing arbitrary patterns in markdown](#optionsadditionalparserrules---parsing-arbitrary-patterns-in-markdown)
     - [options.createElement - Custom React.createElement behavior](#optionscreateelement---custom-reactcreateelement-behavior)
     - [options.slugify](#optionsslugify)
     - [options.namedCodesToUnicode](#optionsnamedcodestounicode)
@@ -372,6 +373,59 @@ render(
     />,
     document.body
 );
+```
+
+#### options.additionalParserRules - Parsing arbitrary patterns in markdown
+
+Pass the `options.additionalParserRules` property to the `compiler` or `<Markdown>` component to parse and replace arbitrary patterns in the markdown.
+
+You can use the enum `Priority` for order value.
+
+```jsx
+import Markdown from 'markdown-to-jsx';
+import React from 'react';
+
+// Matches a string that starts and end with `+`
+const customRegexMatcher =
+    /^([+])\1((?:\[.*?\][([].*?[)\]]|<.*?>(?:.*?<.*?>)?|`.*?`|~+.*?~+|.)*?)\1\1(?!\1)/;
+
+const md = `
+# Hello ++world++!
+`;
+
+render(
+    <Markdown
+        children={md}
+        options={{
+            additionalParserRules: {
+                example: {
+                    match: (source: string) => customRegexMatcher.exec(source),
+                    order: Priority.MED,
+                    parse: (capture, parse, state) => {
+                        return {
+                            content: parse(capture[2], state),
+                        }
+                    },
+                    react: (node, output, state) => {
+                        return <u key={state.key}>{output(node.content, state)}</u>
+                    },
+                },
+            },
+        }}
+    />,
+    document.body
+);
+/*
+    renders:
+
+    <span>
+        Hello
+        <u>
+          world
+        </u>
+        !
+    </span>
+ */
 ```
 
 #### options.createElement - Custom React.createElement behavior

--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -860,7 +860,11 @@ describe('links', () => {
   })
 
   it('should not link URL if it is nested inside an anchor tag', () => {
-    render(compiler('<a href="https://google.com">some text <span>with a link https://google.com</span></a>'))
+    render(
+      compiler(
+        '<a href="https://google.com">some text <span>with a link https://google.com</span></a>'
+      )
+    )
 
     expect(root.innerHTML).toMatchInlineSnapshot(`
       <a href="https://google.com">
@@ -871,7 +875,11 @@ describe('links', () => {
       </a>
     `)
 
-    render(compiler('<a href="https://google.com">some text <span>with a nested link <span>https://google.com</span></span></a>'))
+    render(
+      compiler(
+        '<a href="https://google.com">some text <span>with a nested link <span>https://google.com</span></span></a>'
+      )
+    )
 
     expect(root.innerHTML).toMatchInlineSnapshot(`
       <a href="https://google.com">

--- a/index.tsx
+++ b/index.tsx
@@ -161,6 +161,11 @@ export namespace MarkdownToJSX {
      * HTML IDs for anchor linking purposes.
      */
     slugify: (source: string) => string
+
+    /**
+     * Add additional rules for parsing the markdown
+     */
+    additionalParserRules: MarkdownToJSX.Rules
   }>
 }
 
@@ -903,7 +908,7 @@ function getTag(tag: string, overrides: MarkdownToJSX.Overrides) {
     : get(overrides, `${tag}.component`, tag)
 }
 
-enum Priority {
+export enum Priority {
   /**
    * anything that must scan the tree before everything else
    */
@@ -935,6 +940,7 @@ export function compiler(
   options.namedCodesToUnicode = options.namedCodesToUnicode
     ? { ...namedCodesToUnicode, ...options.namedCodesToUnicode }
     : namedCodesToUnicode
+  options.additionalParserRules = options.additionalParserRules || {}
 
   const createElementFn = options.createElement || React.createElement
 
@@ -1700,6 +1706,8 @@ export function compiler(
         return <del key={state.key}>{output(node.content, state)}</del>
       },
     } as MarkdownToJSX.Rule<ReturnType<typeof parseCaptureInline>>,
+
+    ...options.additionalParserRules,
   }
 
   // Object.keys(rules).forEach(key => {


### PR DESCRIPTION
This PR should allow for custom markdown syntax parsing as requested in this issue: https://github.com/probablyup/markdown-to-jsx/issues/313

I added a new property named `additionalParserRules` that can be given `MarkdownToJSX.Rules` which are added at the end of the already existing rules.