### PR TITLE
Set type of package to module

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "import": "./dist/index.modern.js",
     "require": "./dist/index.js"
   },
+  "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.module.js",
   "source": "index.tsx",


### PR DESCRIPTION
It's great that this package builds and publishes esmodule ready code via the `"exports"` key in package.json, however if you try to `import` this package from another esmodule file, node will present an error `SyntaxError: Cannot use import statement outside a module`.

It's likely this has gone unnoticed since most will be importing this directly from TypeScript, which compiles code down to another target, but this will reproduce if you import in a vanilla node environment.

There are two ways to fix this, either the esmodule code needs to use the `.mjs` extensions, or the package.json needs to include `"type": "module"`. Either will tell node that the referenced file should be interpreted as a module instead of a script.

I've proposed what was easier to introduce, adding the line to package.json