### PR TITLE
Disable esModuleInterop and remove unquote dependency

### DIFF
--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -1,8 +1,8 @@
 import { compiler } from './index'
-import React from 'react'
-import ReactDOM from 'react-dom'
-import fs from 'fs'
-import theredoc from 'theredoc'
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import * as fs from 'fs'
+import * as theredoc from 'theredoc'
 
 const root = document.body.appendChild(
   document.createElement('div')

--- a/index.component.spec.tsx
+++ b/index.component.spec.tsx
@@ -1,6 +1,6 @@
 import Markdown from './index'
-import React from 'react'
-import ReactDOM from 'react-dom'
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
 
 const root = document.body.appendChild(document.createElement('div'))
 

--- a/index.tsx
+++ b/index.tsx
@@ -4,9 +4,7 @@
  * from Khan Academy. Thank you Khan devs for making such an awesome and extensible
  * parsing infra... without it, half of the optimizations here wouldn't be feasible. 🙏🏼
  */
-import React from 'react'
-/// <reference path="unquote.d.ts" />
-import unquote from 'unquote'
+import * as React from 'react'
 
 export namespace MarkdownToJSX {
   /**
@@ -424,6 +422,19 @@ const BLOCK_SYNTAXES = [
 
 function containsBlockSyntax(input: string) {
   return BLOCK_SYNTAXES.some(r => r.test(input))
+}
+
+/** Remove symmetrical leading and trailing quotes */
+function unquote(str: string) {
+  const first = str[0]
+  if (
+    (first === '"' || first === "'") &&
+    str.length >= 2 &&
+    str[str.length - 1] === first
+  ) {
+    return str.slice(1, -1)
+  }
+  return str
 }
 
 // based on https://stackoverflow.com/a/18123682/1141611

--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "styled-components": "^5.1.1",
     "theredoc": "^1.0.0",
     "ts-jest": "^27.0.3",
-    "typescript": "^4.1.3",
-    "unquote": "^1.1.0"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "react": ">= 0.14.0"
@@ -92,6 +91,13 @@
   ],
   "jest": {
     "preset": "ts-jest",
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "ignoreCodes": ["TS151001"]
+        }
+      }
+    },
     "testEnvironment": "jsdom",
     "snapshotSerializers": [
       "jest-serializer-html"

--- a/site.tsx
+++ b/site.tsx
@@ -1,7 +1,7 @@
 /* @jsx React.createElement */
 import { lighten, rgba } from 'polished'
-import React from 'react'
-import ReactDOM from 'react-dom'
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
 import styled, { createGlobalStyle, css, CSSProp } from 'styled-components'
 import Markdown from './'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "esModuleInterop": true,
+    // Disable because enabling this option can also force consuming libraries to enable it
+    "esModuleInterop": false,
     "incremental": true,
     "jsx": "react",
     "module": "ESNext",

--- a/unquote.d.ts
+++ b/unquote.d.ts
@@ -1,3 +1,0 @@
-declare module 'unquote' {
-  export default function(input: string): string;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8248,7 +8248,7 @@ universalify@^0.1.0, universalify@^0.1.2:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-unquote@^1.1.0, unquote@~1.1.1:
+unquote@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
   integrity sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=


### PR DESCRIPTION
For reasons outlined in #425, disable `esModuleInterop` and update all relevant imports.

When I disabled `esModuleInterop`, microbundle (rollup) started giving a warning "cannot call a namespace" regarding `unquote`. It turns out [the implementation of unquote](https://github.com/lakenen/node-unquote/blob/master/index.js) is super simple and not even entirely correct (doesn't verify quotes are symmetric), so I removed the dependency and added a local implementation. (This would also be doable in 2 lines with regex `/^(['"])(.*)\1$/` but it will be a little slower--not sure how much it matters here.)

Fixes #425