### PR TITLE
Resolve issue with catastrophic backtracking regex

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -259,7 +259,7 @@ const BLOCK_END_R = /\n{2,}$/
 const BLOCKQUOTE_R = /^( *>[^\n]+(\n[^\n]+)*\n*)+\n{2,}/
 const BLOCKQUOTE_TRIM_LEFT_MULTILINE_R = /^ *> ?/gm
 const BREAK_LINE_R = /^ {2,}\n/
-const BREAK_THEMATIC_R = /^(?:( *[-*_]) *){3,}(?:\n *)+\n/
+const BREAK_THEMATIC_R = /^(?:( *[-*_])){3,} *(?:\n *)+\n/
 const CODE_BLOCK_FENCED_R =
   /^\s*(`{3,}|~{3,}) *(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n *)+\n?/
 const CODE_BLOCK_R = /^(?: {4}[^\n]+\n*)+(?:\n *)+\n?/


### PR DESCRIPTION
[Catastrophic backtracking](https://www.regular-expressions.info/catastrophic.html) in the `BREAK_THEMATIC_R` regex causes parsing to hang on non-matching input with repeating asterisks like this:
```
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
SOME TEXT
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
```
or even just:
```
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
```
This minor regex change resolves that issue without changing the matched pattern or capture group.