### PR TITLE
Try to fix multi blockquotes

### DIFF
--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -455,14 +455,26 @@ describe('inline textual elements', () => {
 
 describe('misc block level elements', () => {
   it('should handle blockquotes', () => {
-    render(compiler('> Something important, perhaps?'))
+    render(
+      compiler(
+        '> Something important, perhaps?\n> Trying to fix multi blockquotes, perhaps?'
+      )
+    )
 
     expect(root.innerHTML).toMatchInlineSnapshot(`
-      <blockquote>
-        <p>
-          Something important, perhaps?
-        </p>
-      </blockquote>
+      <div>
+        <blockquote>
+          <p>
+            Something important, perhaps?
+          </p>
+        </blockquote>
+        <blockquote>
+          <p>
+            Trying to fix multi blockquotes, perhaps?
+          </p>
+        </blockquote>
+        ?
+      </div>
     `)
   })
 })
@@ -892,7 +904,11 @@ describe('links', () => {
   })
 
   it('should not link URL if it is nested inside an anchor tag', () => {
-    render(compiler('<a href="https://google.com">some text <span>with a link https://google.com</span></a>'))
+    render(
+      compiler(
+        '<a href="https://google.com">some text <span>with a link https://google.com</span></a>'
+      )
+    )
 
     expect(root.innerHTML).toMatchInlineSnapshot(`
       <a href="https://google.com">
@@ -903,7 +919,11 @@ describe('links', () => {
       </a>
     `)
 
-    render(compiler('<a href="https://google.com">some text <span>with a nested link <span>https://google.com</span></span></a>'))
+    render(
+      compiler(
+        '<a href="https://google.com">some text <span>with a nested link <span>https://google.com</span></span></a>'
+      )
+    )
 
     expect(root.innerHTML).toMatchInlineSnapshot(`
       <a href="https://google.com">

--- a/index.tsx
+++ b/index.tsx
@@ -256,7 +256,7 @@ const ATTR_EXTRACTOR_R =
 
 const AUTOLINK_MAILTO_CHECK_R = /mailto:/i
 const BLOCK_END_R = /\n{2,}$/
-const BLOCKQUOTE_R = /^( *>[^\n]+(\n[^\n]+)*\n*)+\n{2,}/
+const BLOCKQUOTE_R = /^\> (.*$)/gim
 const BLOCKQUOTE_TRIM_LEFT_MULTILINE_R = /^ *> ?/gm
 const BREAK_LINE_R = /^ {2,}\n/
 const BREAK_THEMATIC_R = /^(?:( *[-*_]) *){3,}(?:\n *)+\n/


### PR DESCRIPTION
Hi @probablyup 
I would apprecaite when you have time to look into this PR. Please advice me if something off or need to be changed. Thanks in advance.

**Description:**

fixing multi blockquotes.

**Issue:**
As soon we have multi blockquotes in markdown, it just wrapping them in one blockquotes.

**Reference of the issue:**
https://github.com/probablyup/markdown-to-jsx/issues/399
