### PR TITLE
chore: add types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   ],
   "exports": {
     "import": "./dist/index.modern.js",
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "main": "dist/index.js",
   "module": "dist/index.module.js",


### PR DESCRIPTION
This is required to make `moduleResolution: NodeNext` work.

Also requires https://github.com/probablyup/markdown-to-jsx/pull/414