### PR TITLE
feat: add support for "mark" syntax `==text==`

### DIFF
--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -303,6 +303,20 @@ describe('inline textual elements', () => {
     `)
   })
 
+  it('should handle marked text containing other syntax with an equal sign', () => {
+    render(compiler('==Foo `==bar` baz.=='))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <mark>
+        Foo
+        <code>
+          ==bar
+        </code>
+        baz.
+      </mark>
+    `)
+  })
+
   it('should handle block deleted text containing other syntax with a tilde', () => {
     render(compiler('~~Foo `~~bar` baz.~~\n\nFoo ~~bar~~.'))
 

--- a/index.tsx
+++ b/index.tsx
@@ -333,6 +333,7 @@ const TEXT_BOLD_R =
   /^([*_])\1((?:\[.*?\][([].*?[)\]]|<.*?>(?:.*?<.*?>)?|`.*?`|~+.*?~+|.)*?)\1\1(?!\1)/
 const TEXT_EMPHASIZED_R =
   /^([*_])((?:\[.*?\][([].*?[)\]]|<.*?>(?:.*?<.*?>)?|`.*?`|~+.*?~+|.)*?)\1(?!\1|\w)/
+const TEXT_MARKED_R = /^==((?:\[.*?\]|<.*?>(?:.*?<.*?>)?|`.*?`|.)*?)==/
 const TEXT_STRIKETHROUGHED_R = /^~~((?:\[.*?\]|<.*?>(?:.*?<.*?>)?|`.*?`|.)*?)~~/
 
 const TEXT_ESCAPED_R = /^\\([^0-9A-Za-z\s])/
@@ -1819,6 +1820,15 @@ export function compiler(
         }
       },
     },
+
+    textMarked: {
+      _match: simpleInlineRegex(TEXT_MARKED_R),
+      _order: Priority.LOW,
+      _parse: parseCaptureInline,
+      _react(node, output, state) {
+        return <mark key={state._key}>{output(node._content, state)}</mark>
+      },
+    } as MarkdownToJSX.Rule<ReturnType<typeof parseCaptureInline>>,
 
     textStrikethroughed: {
       _match: simpleInlineRegex(TEXT_STRIKETHROUGHED_R),


### PR DESCRIPTION
This is a newer syntax used in some tools like Quill, Obsidian, etc that will ideally be added to CommonMark in the near future.

Fixes #470