### PR TITLE
Allowing implicit links in markdown text

### DIFF
--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -771,6 +771,130 @@ describe('links', () => {
     `)
   })
 
+  it('should handle a collapsed reference link', () => {
+    render(compiler(['[foo][]', '[foo]: /url'].join('\n')))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <a href="/url">
+          foo
+        </a>
+      </p>
+    `)
+  })
+
+  it('should handle a collapsed reference link with title', () => {
+    render(compiler(['[foo][]', '[foo]: /url "bar"'].join('\n')))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <a href="/url"
+           title="bar"
+        >
+          foo
+        </a>
+      </p>
+    `)
+  })
+
+  it('should handle a collapsed reference link with formatted label', () => {
+    render(compiler(['[*foo* bar][]', '[*foo* bar]: /url "title"'].join('\n')))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <a href="/url"
+           title="title"
+        >
+          <em>
+            foo
+          </em>
+          bar
+        </a>
+      </p>
+    `)
+  })
+
+  it('should handle a shortcut reference link', () => {
+    render(compiler(['[foo]', '[foo]: /url'].join('\n')))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <a href="/url">
+          foo
+        </a>
+      </p>
+    `)
+  })
+
+  it('should handle a shortcut reference link with title', () => {
+    render(compiler(['[foo]', '[foo]: /url "bar"'].join('\n')))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <a href="/url"
+           title="bar"
+        >
+          foo
+        </a>
+      </p>
+    `)
+  })
+
+  it('should handle a shortcut reference link with formatted label', () => {
+    render(compiler(['[*foo* bar]', '[*foo* bar]: /url "title"'].join('\n')))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <a href="/url"
+           title="title"
+        >
+          <em>
+            foo
+          </em>
+          bar
+        </a>
+      </p>
+    `)
+  })
+
+  it('should preserve a space after a shortcut reference link', () => {
+    render(compiler(['[foo] bar', '[foo]: /url'].join('\n')))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <a href="/url">
+          foo
+        </a>
+        bar
+      </p>
+    `)
+  })
+
+  it('should not treat brackets as a shortcut reference link when there is no defined link', () => {
+    render(compiler(['These [brackets] are not a link', '[foo]: /url "bar"'].join('\n')))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        These [brackets] are not a link.
+      </p>
+    `)
+  })
+
+  it('should treat a collapsed reference link with a space as a shortcut reference link', () => {
+    render(compiler(['[foo] []', '[foo]: /url "bar"'].join('\n')))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <a href="/url"
+           title="bar"
+        >
+          foo
+        </a>
+        []
+      </p>
+    `)
+  })
+
   it('list item should break paragraph', () => {
     render(compiler('foo\n- item'))
 

--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -875,7 +875,7 @@ describe('links', () => {
 
     expect(root.innerHTML).toMatchInlineSnapshot(`
       <p>
-        These [brackets] are not a link.
+        These [brackets] are not a link
       </p>
     `)
   })


### PR DESCRIPTION
In response to issue #454, I've attempted a patch to handle "implicit" links according to the CommonMark specification. There are two types of these links: [collapsed](https://spec.commonmark.org/0.30/#collapsed-reference-link) and [shortcut](https://spec.commonmark.org/0.30/#shortcut-reference-link) reference links.

This commit handles both of those syntaxes. It allows for the following markdown:

```markdown
I am a [collapsed][]reference link.

I am a [shortcut] reference link.

[collapsed]: /url1
[shortcut]: /url2
```

I've added as many tests as I could manage, and everything is still passing. I didn't dive into testing precedence between the various types of links, although that is certainly something that could be tested for.

I'm fairly certain the two functions `refLinkCollapsed()` and `refLinkShortcut()` (and the corresponding regexes) _could_ be combined, but I couldn't quite pull that off myself.

Please let me know if there are any changes needed, or if you have any questions or feedback. Thanks!