### PR TITLE
fix: Update package.json for "type": "module" with updated `size-limit` tests for `index.cjs` and `index.module.js` (replacing `index.js`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "size-limit": [
     {
-      "path": "dist/index.js",
+      "path": "./dist/index.js",
       "limit": "6 kB"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "LICENSE",
     "README.md"
   ],
+  "type": "module",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.modern.js",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.module.js",
   "source": "index.tsx",
   "unpkg": "./dist/index.umd.js",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,11 @@
   },
   "size-limit": [
     {
-      "path": "./dist/index.js",
+      "path": "./dist/index.cjs",
+      "limit": "6 kB"
+    },
+    {
+      "path": "./dist/index.module.js",
       "limit": "6 kB"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -25,12 +25,18 @@
   ],
   "type": "module",
   "exports": {
-    "./package.json": "./package.json",
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.modern.js",
-      "require": "./dist/index.cjs"
-    }
+      "import": {
+        "types": "./index.d.ts",
+        "node": "./dist/index.module.js",
+        "default": "./dist/index.modern.js"
+      },
+      "require": {
+        "types": "./dist/index.cjs.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.module.js",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
         "types": "./dist/index.cjs.d.ts",
         "default": "./dist/index.cjs"
       }
-    },
-    "./package.json": "./package.json"
+    }
   },
   "main": "dist/index.cjs",
   "module": "dist/index.module.js",


### PR DESCRIPTION
Closes #498
Fixes #495

This would fix https://github.com/probablyup/markdown-to-jsx/issues/495. This PR specifically is attempting to retry build tests for https://github.com/probablyup/markdown-to-jsx/pull/498 with most-recent code base, as well as updating the tests run in `package.json` relating to `size-limit` and `npm run size`. 

The issues with https://github.com/probablyup/markdown-to-jsx/pull/498 are solely related to the github action not being able to find index.js. It looks like changing `type` to `module` affects the build command (`npm run build`), such that `index.js` is no longer output, but `index.cjs` (for common) and `index.module.js` (for ES) are output, which in turn affects the `size-limit` config in `package.json` (since the output file `index.js` that the test--`npm run size`--builds on no longer exists). Updating this test, and including the original change from @greypants in https://github.com/probablyup/markdown-to-jsx/pull/498, now passes all tests successfully. 

This would finally fix the `Cannot use import statement outside a module` error originally noted in https://github.com/probablyup/markdown-to-jsx/issues/495 with 100% passing tests.