### PR TITLE
fix: correctly parse markdown inside of a table row when a preceding column has nested HTML elements

### DIFF
--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -1954,6 +1954,37 @@ describe('GFM tables', () => {
       </table>
     `)
   })
+
+  it('processeses HTML inside of a table row', () => {
+    render(
+      compiler(theredoc`
+        | Header                     |
+        | -------------------------- |
+        | <div>I'm in a "div"!</div> |
+      `)
+    )
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <table>
+        <thead>
+          <tr>
+            <th>
+              Header
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <div>
+                I'm in a "div"!
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    `)
+  })
 })
 
 describe('arbitrary HTML', () => {

--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -1986,7 +1986,7 @@ describe('GFM tables', () => {
     `)
   })
 
-  it('process markdown inside of a table row when a preceeding column contains HTML', () => {
+  it('processes markdown inside of a table row when a preceeding column contains HTML', () => {
     render(
       compiler(theredoc`
         | Column A                   | Column B                 |
@@ -2017,6 +2017,47 @@ describe('GFM tables', () => {
             <td>
               <strong>
                 Hello from column B!
+              </strong>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    `)
+  })
+
+  it('process markdown inside of a table row when a preceeding column contains HTML with nested elements', () => {
+    render(
+      compiler(theredoc`
+        | Nested HTML                        | MD                   |
+        | ---------------------------------- | -------------------- |
+        | <div><strong>Nested</strong></div> | **I should be bold** |
+      `)
+    )
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <table>
+        <thead>
+          <tr>
+            <th>
+              Nested HTML
+            </th>
+            <th>
+              MD
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <div>
+                <strong>
+                  Nested
+                </strong>
+              </div>
+            </td>
+            <td>
+              <strong>
+                I should be bold
               </strong>
             </td>
           </tr>

--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -2104,6 +2104,47 @@ describe('GFM tables', () => {
       </table>
     `)
   })
+
+  it('processes a markdown link inside of a table row when a preceeding column contains HTML with nested elements', () => {
+    render(
+      compiler(theredoc`
+        | Nested HTML                        | Link                         |
+        | ---------------------------------- | ---------------------------- |
+        | <div><strong>Nested</strong></div> | [I'm a link](www.google.com) |
+      `)
+    )
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <table>
+        <thead>
+          <tr>
+            <th>
+              Nested HTML
+            </th>
+            <th>
+              Link
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <div>
+                <strong>
+                  Nested
+                </strong>
+              </div>
+            </td>
+            <td>
+              <a href="www.google.com">
+                I'm a link
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    `)
+  })
 })
 
 describe('arbitrary HTML', () => {

--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -2025,7 +2025,46 @@ describe('GFM tables', () => {
     `)
   })
 
-  it('process markdown inside of a table row when a preceeding column contains HTML with nested elements', () => {
+  it('processes HTML inside of a table row when a preceeding column contains markdown', () => {
+    render(
+      compiler(theredoc`
+        | Markdown         | HTML                          |
+        | ---------------- | ----------------------------- |
+        | **I'm Markdown** | <strong>And I'm HTML</strong> |
+      `)
+    )
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <table>
+        <thead>
+          <tr>
+            <th>
+              Markdown
+            </th>
+            <th>
+              HTML
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <strong>
+                I'm Markdown
+              </strong>
+            </td>
+            <td>
+              <strong>
+                And I'm HTML
+              </strong>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    `)
+  })
+
+  it('processes markdown inside of a table row when a preceeding column contains HTML with nested elements', () => {
     render(
       compiler(theredoc`
         | Nested HTML                        | MD                   |

--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -1985,6 +1985,45 @@ describe('GFM tables', () => {
       </table>
     `)
   })
+
+  it('process markdown inside of a table row when a preceeding column contains HTML', () => {
+    render(
+      compiler(theredoc`
+        | Column A                   | Column B                 |
+        | -------------------------- | ------------------------ |
+        | <div>I'm in column A</div> | **Hello from column B!** |
+      `)
+    )
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <table>
+        <thead>
+          <tr>
+            <th>
+              Column A
+            </th>
+            <th>
+              Column B
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <div>
+                I'm in column A
+              </div>
+            </td>
+            <td>
+              <strong>
+                Hello from column B!
+              </strong>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    `)
+  })
 })
 
 describe('arbitrary HTML', () => {

--- a/index.tsx
+++ b/index.tsx
@@ -1058,7 +1058,7 @@ function parseBlock(
   state: MarkdownToJSX.State
 ): MarkdownToJSX.ParserResult {
   state._inline = false
-  return parse(content + '\n\n', state)
+  return parse(content, state)
 }
 
 const parseCaptureInline: MarkdownToJSX.Parser<

--- a/index.tsx
+++ b/index.tsx
@@ -1741,6 +1741,7 @@ export function compiler(
         if (!state._inTable) {
           return null
         }
+        state._inline = true
         return TABLE_SEPARATOR_R.exec(source)
       },
       _order: Priority.HIGH,


### PR DESCRIPTION
This fixes #488. The issue I found was that when parsing HTML within a markdown table row, if there are nested HTML elements, then when we enter the `parseBlock` function and set `state._inline` to `false`, it prevents any rules using `inlineRegex` or `simpleInlineRegex` when we move on to process other cells in the table. I also added a very basic test for processing HTML within a table row because I didn't see one there. Interested to hear your feedback on this!